### PR TITLE
RXR-602 fix issue lag time for models with multiple compartments

### DIFF
--- a/R/apply_lagtime.R
+++ b/R/apply_lagtime.R
@@ -17,11 +17,12 @@ apply_lagtime <- function(regimen, lagtime, parameters) {
       if(length(lagtime) == 1) {
         regimen$dose_times <- regimen$dose_times + parameters[[lagtime]]
       } else {
-        if(!is.null(regimen$cmt)) {
-          par_tmp <- parameters
-          par_tmp[["0"]] <- 0
-          regimen$dose_times <- regimen$dose_times + as.numeric(unlist(par_tmp[lagtime[regimen$cmt]]))
+        if(is.null(regimen$cmt)) {
+          regimen$cmt <- rep(1, length(regimen$dose_times))
         }
+        par_tmp <- parameters
+        par_tmp[["0"]] <- 0
+        regimen$dose_times <- regimen$dose_times + as.numeric(unlist(par_tmp[lagtime[regimen$cmt]]))
       }
     }
     return(regimen)

--- a/tests/testthat/test_apply_lagtime.R
+++ b/tests/testthat/test_apply_lagtime.R
@@ -20,3 +20,13 @@ test_that("lagtime applied to regimens using lagtime arg", {
   expect_true("regimen" %in% class(lag2))
   expect_equal(lag2$dose_times, reg1$dose_times + 0.75)
 })
+
+test_that("lagtime applied when multiple compartments and no compartment specified in regimen", {
+  lag3 <- apply_lagtime(
+    regimen = reg1,
+    lagtime = c("TLAG", 0, 0),
+    parameters = list(CL = 5, V = 50, TLAG = .5)
+  )
+  expect_true("regimen" %in% class(lag3))
+  expect_equal(lag3$dose_times, reg1$dose_times + 0.5)
+})


### PR DESCRIPTION
A bug was present when lagtime was specified as a parameter in a model (e.g. TLAG), and the lag time definition specified as a vector for the compartments, e.g. `["TLAG", 0, 0]`. This caused the lag-time not to be applied. This PR fixes that behavior and updates unit tests to include that scenario.