### PR TITLE
RXR-616: fix bug multiple infusion stop events

### DIFF
--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -224,6 +224,11 @@ create_event_table <- function(
   if(!is.null(obs_type)) {
     design <- merge(design, data.frame(t = t_obs, obs_type), all=TRUE)
     design$obs_type <- ifelse(is.na(design$obs_type), 0, as.integer(design$obs_type))
+    # merging can induce multiple infusion stop events, should reset those:
+    duplicate_stop <- design$evid == 2 & duplicated(design$t)
+    if(any(duplicate_stop)) {
+      design$rate[duplicate_stop] <- 0
+    }
   }
   design <- design[order(design$t, design$type, design$dum, decreasing=FALSE),]
   if(t_init != 0) { # add event line at t=0, to start integration

--- a/R/sim.R
+++ b/R/sim.R
@@ -387,7 +387,7 @@ sim <- function (ode = NULL,
     p_i <- p
     if(!is.null(covariates_table)) {
       covariates_tmp <- covariates_table[[i]]
-      design_i <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init, p_i, covariates_table[[i]])
+      design_i <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init, p_i, covariates_table[[i]], model = ode, obs_type = obs_type)
     } else {
       covariates_tmp <- covariates
     }

--- a/tests/testthat/test_create_event_table.R
+++ b/tests/testthat/test_create_event_table.R
@@ -73,3 +73,22 @@ test_that("Rounding-related index matching issues in time col", {
   )
   expect_equal(sum(is.na(res2$cov_PMA)), 0)
 })
+
+test_that("Multiple obs_types does not add erroneuous infusion stop events", {
+  reg <- new_regimen(
+    amt = c(100, 100, 100, 100),
+    times = c(0, 336, 672, 1008),
+    t_inf = 3,
+    type = "infusion"
+  )
+  res <- create_event_table(
+    regimen = reg,
+    t_max = NULL,
+    t_obs = c(3, 3.5, 4, 6, 8, 12, 16, 330, 340, 670, 676, 1005, 1200,
+              3, 3.5, 4, 6, 8, 12, 16, 330, 340, 670, 676, 1005, 1200),
+    obs_type = c(1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2),
+    covariates = list(WT = new_covariate(70)),
+    model = NULL
+  )
+  expect_true(all(cumsum(res$rate) >= 0)) # cumulative dose rate should never be lower than zero
+})


### PR DESCRIPTION
When a simulation was performed with multiple observation types *and* on of the specified observation times coincided with an infusion stop event, the infusion stop event would be repeated due to a merge action. This resulted in negative infusion rates.