### PR TITLE
RXR-639 reduce package size (strip libs)

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,4 @@
+strippedLib: $(SHLIB)
+	if test -e "/usr/bin/strip" & test -e "/bin/uname" & [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi
+.phony: strippedLib
+


### PR DESCRIPTION
Requires trick described here:

http://dirk.eddelbuettel.com/blog/2017/08/14/#009_compact_shared_libraries
https://stackoverflow.com/questions/46280628/object-files-in-r-package-too-large-rcpp

With the Makevars file, the NOTE about pkg size is not thrown anymore.