### PR TITLE
RXR-635: Skip slow tests on CRAN

### DIFF
--- a/tests/testthat/test_advan_with_auc.R
+++ b/tests/testthat/test_advan_with_auc.R
@@ -1,71 +1,74 @@
-dose <- 100
-interval <- 12
-n_days <- 5
-t_inf <- 1.5
-parameters <- list(
-  CL = 10,
-  V = 50,
-  KA = 0.5,
-  Q = 5,
-  V2 = 100,
-  Q2 = 3,
-  V3 = 150,
-  F1 = 1
-)
-t_obs <- c(3, 6, 8, 23, 47)
+if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+  dose <- 100
+  interval <- 12
+  n_days <- 5
+  t_inf <- 1.5
+  parameters <- list(
+    CL = 10,
+    V = 50,
+    KA = 0.5,
+    Q = 5,
+    V2 = 100,
+    Q2 = 3,
+    V3 = 150,
+    F1 = 1
+  )
+  t_obs <- c(3, 6, 8, 23, 47)
 
-## ODE models for testing
-mod_1cmt <- new_ode_model(
-  code="dAdt[1] = -(CL/V)*A[1]; dAdt[2] = A[1]/V;",
-  parameters = parameters
-)
-mod_2cmt <- new_ode_model(
-  code="
+  ## ODE models for testing
+  mod_1cmt <- new_ode_model(
+    code="dAdt[1] = -(CL/V)*A[1]; dAdt[2] = A[1]/V;",
+    parameters = parameters
+  )
+  mod_2cmt <- new_ode_model(
+    code="
     dAdt[1] = -(CL/V)*A[1] - (Q/V)*A[1] + (Q/V2)*A[2];
     dAdt[2] = +(Q/V)*A[1] - (Q/V2)*A[2];
     dAdt[3] = A[1]/V;
   ",
   parameters = parameters
-)
-mod_3cmt <- new_ode_model(
-  code="
+  )
+  mod_3cmt <- new_ode_model(
+    code="
     dAdt[1] = -(CL/V)*A[1] - (Q/V)*A[1] + (Q/V2)*A[2] - (Q2/V)*A[1] + (Q2/V3)*A[3];
     dAdt[2] =                (Q/V)*A[1]  -(Q/V2)*A[2]                             ;
     dAdt[3] =                                           (Q2/V)*A[1] - (Q2/V3)*A[3];
     dAdt[4] = A[1]/V;
   ",
   parameters = parameters
-)
+  )
 
-## bolus dataset
-reg_bolus <- new_regimen(
-  amt = dose,
-  times = seq(0, interval * n_days * (24/interval), interval),
-  t_inf = t_inf,
-  type = "bolus"
-)
-data_bolus <- advan_create_data(
-  reg_bolus,
-  parameters = parameters,
-  cmts = 5,
-  t_obs = t_obs
-)
+  ## bolus dataset
+  reg_bolus <- new_regimen(
+    amt = dose,
+    times = seq(0, interval * n_days * (24/interval), interval),
+    t_inf = t_inf,
+    type = "bolus"
+  )
+  data_bolus <- advan_create_data(
+    reg_bolus,
+    parameters = parameters,
+    cmts = 5,
+    t_obs = t_obs
+  )
 
-## Infusion dataset
-reg_infusion <- new_regimen(
-  amt = dose,
-  times = seq(0, interval * n_days * (24/interval), interval),
-  t_inf = t_inf,
-  type = "infusion"
-)
-data_infusion <- advan_create_data(
-  reg_infusion,
-  parameters = parameters,
-  cmts = 6,
-  t_obs = t_obs
-)
+  ## Infusion dataset
+  reg_infusion <- new_regimen(
+    amt = dose,
+    times = seq(0, interval * n_days * (24/interval), interval),
+    t_inf = t_inf,
+    type = "infusion"
+  )
+  data_infusion <- advan_create_data(
+    reg_infusion,
+    parameters = parameters,
+    cmts = 6,
+    t_obs = t_obs
+  )
+}
 
 test_that("One compartment bolus ADVAN runs", {
+  skip_on_cran()
   res1_iv_r <- advan("1cmt_iv_bolus", cpp=FALSE)(data_bolus)
   res1_iv_c <- advan("1cmt_iv_bolus", cpp=TRUE)(data_bolus)
   res1_iv_ode <- sim(ode = mod_1cmt, regimen = reg_bolus, parameters = parameters, t_obs = t_obs)
@@ -78,6 +81,7 @@ test_that("One compartment bolus ADVAN runs", {
 })
 
 test_that("Two compartment bolus ADVAN runs", {
+  skip_on_cran()
   res2_iv_r <- advan("2cmt_iv_bolus", cpp=FALSE)(data_bolus)
   res2_iv_c <- advan("2cmt_iv_bolus", cpp=TRUE)(data_bolus)
   res2_iv_ode <- sim(ode = mod_2cmt, regimen = reg_bolus, parameters = parameters, t_obs = t_obs)
@@ -99,6 +103,7 @@ test_that("Two compartment bolus ADVAN runs", {
 })
 
 test_that("Two compartment infusion ADVAN runs", {
+  skip_on_cran()
   res2_inf_r <- advan("2cmt_iv_infusion", cpp=FALSE)(data_infusion)
   res2_inf_c <- advan("2cmt_iv_infusion", cpp=TRUE)(data_infusion)
   res2_inf_ode <- sim(ode = mod_2cmt, regimen = reg_infusion, parameters = parameters, t_obs = t_obs)
@@ -123,6 +128,7 @@ test_that("Two compartment infusion ADVAN runs", {
 })
 
 test_that("Three compartment bolus ADVAN runs", {
+  skip_on_cran()
   res3_iv_r <- advan("3cmt_iv_bolus", cpp=FALSE)(data_bolus)
   res3_iv_c <- advan("3cmt_iv_bolus", cpp=TRUE)(data_bolus)
   res3_iv_ode <- sim(ode = mod_3cmt, regimen = reg_bolus, parameters = parameters, t_obs = t_obs)
@@ -144,6 +150,7 @@ test_that("Three compartment bolus ADVAN runs", {
 })
 
 test_that("Three compartment iv ADVAN runs", {
+  skip_on_cran()
   res3_iv_r <- advan("3cmt_iv_infusion", cpp=FALSE)(data_infusion)
   res3_iv_c <- advan("3cmt_iv_infusion", cpp=TRUE)(data_infusion)
   res3_iv_ode <- sim(ode = mod_3cmt, regimen = reg_infusion, parameters = parameters, t_obs = t_obs)

--- a/tests/testthat/test_advan_with_covariates.R
+++ b/tests/testthat/test_advan_with_covariates.R
@@ -1,58 +1,60 @@
-## Create dataset
-dose <- 100
-interval <- 12
-n_days <- 2
-parameters <- list(
-  CL = 10,
-  V = 50,
-  KA = 0.5,
-  Q = 5,
-  V2 = 100,
-  Q2 = 3,
-  V3 = 150,
-  F1 = 1
-)
-t_obs <- seq(0, 40, .1)
-reg_bolus <- new_regimen(
-  amt = dose,
-  times = seq(0, interval * n_days * (24/interval), interval),
-  type = "bolus"
-)
-## there is slight difference in how bolus doses are handled.
-## Analytical equation is perhaps more consistent, so not testing
-## simulations at dose times. Should look into later.
-t_obs <- t_obs[! t_obs %in% reg_bolus$dose_times]
-covariates <- list(WT = new_covariate(80), CRCL=new_covariate(4.5))
+test_that("Analytic and ODE models with covariates are the same", {
+  skip_on_cran()
 
-## Using analytic equations model:
-data_ana <- sim(
-  analytical = "1cmt_iv_bolus",
-  parameters = parameters,
-  covariates = covariates,
-  regimen = reg_bolus,
-  t_obs = t_obs,
-  covariate_model = "CL = CL * (CRCL / 3)^0.75; V = V * (WT / 70.0)"
-)
+  ## Create dataset
+  dose <- 100
+  interval <- 12
+  n_days <- 2
+  parameters <- list(
+    CL = 10,
+    V = 50,
+    KA = 0.5,
+    Q = 5,
+    V2 = 100,
+    Q2 = 3,
+    V3 = 150,
+    F1 = 1
+  )
+  t_obs <- seq(0, 40, .1)
+  reg_bolus <- new_regimen(
+    amt = dose,
+    times = seq(0, interval * n_days * (24/interval), interval),
+    type = "bolus"
+  )
+  ## there is slight difference in how bolus doses are handled.
+  ## Analytical equation is perhaps more consistent, so not testing
+  ## simulations at dose times. Should look into later.
+  t_obs <- t_obs[! t_obs %in% reg_bolus$dose_times]
+  covariates <- list(WT = new_covariate(80), CRCL=new_covariate(4.5))
 
-## Using ODE model:
-mod1 <- new_ode_model(
-  code = "
+  ## Using analytic equations model:
+  data_ana <- sim(
+    analytical = "1cmt_iv_bolus",
+    parameters = parameters,
+    covariates = covariates,
+    regimen = reg_bolus,
+    t_obs = t_obs,
+    covariate_model = "CL = CL * (CRCL / 3)^0.75; V = V * (WT / 70.0)"
+  )
+
+  ## Using ODE model:
+  mod1 <- new_ode_model(
+    code = "
     dAdt[1] = -( (CL*pow(CRCL/3.0, 0.75)) / (V*WT/70.0) ) * A[1];
   ",
   covariates = covariates,
   obs = list(cmt = 1, scale = "V*WT/70.0"), dose = list(cmt = 1)
-)
-data_ode <- sim(
-  ode = mod1,
-  parameters = parameters,
-  covariates = covariates,
-  regimen = reg_bolus,
-  t_obs = t_obs,
-  duplicate_t_obs = TRUE,
-  only_obs = TRUE
-)
+  )
+  data_ode <- sim(
+    ode = mod1,
+    parameters = parameters,
+    covariates = covariates,
+    regimen = reg_bolus,
+    t_obs = t_obs,
+    duplicate_t_obs = TRUE,
+    only_obs = TRUE
+  )
 
-test_that("Analytic and ODE models with covariates are the same", {
   expect_equal(nrow(data_ana), nrow(data_ode))
   expect_equal(round(data_ana$y,4), round(data_ode$y, 4))
 })

--- a/tests/testthat/test_bioav_def.R
+++ b/tests/testthat/test_bioav_def.R
@@ -2,8 +2,12 @@ parameters <- list(KA = 0.5, CL = 5, V = 50)
 covs <- list(WT = new_covariate(50))
 reg <- new_regimen(amt = 100, n = 1, interval = 12, type = "bolus")
 mod1 <- oral_1cmt_allometric # defined in setup.R using same covs and pars as above
-mod2 <- new_ode_model(
-  code = "
+y1 <- sim_ode(mod1, parameters = parameters, regimen = reg, covariates = covs, only_obs=TRUE)$y
+
+test_that("bioav numeric option working", {
+  skip_on_cran()
+  mod2 <- new_ode_model(
+    code = "
     CLi = CL * pow(WT/70, 0.75)
     dAdt[1] = -KA * A[1]
     dAdt[2] = KA*A[1] - (CLi/V)*A[2]
@@ -12,9 +16,17 @@ mod2 <- new_ode_model(
   covariates = covs,
   declare_variables = "CLi",
   parameters = parameters
-)
-mod3 <- new_ode_model(
-  code = "
+  )
+
+  y2 <- sim_ode(mod2, parameters = parameters, regimen = reg, covariates = covs, only_obs=TRUE)$y
+
+  expect_equal(round(y1,1),  round(y2*2, 1))
+})
+
+test_that("bioav string option working", {
+  skip_on_cran()
+  mod3 <- new_ode_model(
+    code = "
     CLi = CL * pow(WT/70, 0.75)
     dAdt[1] = -KA * A[1]
     dAdt[2] = KA*A[1] - (CLi/V)*A[2]
@@ -23,17 +35,10 @@ mod3 <- new_ode_model(
   covariates = covs,
   declare_variables = "CLi",
   parameters = parameters
-)
+  )
 
-y1 <- sim_ode(mod1, parameters = parameters, regimen = reg, covariates = covs, only_obs=TRUE)$y
-y2 <- sim_ode(mod2, parameters = parameters, regimen = reg, covariates = covs, only_obs=TRUE)$y
-y3 <- sim_ode(mod3, parameters = parameters, regimen = reg, covariates = covs, only_obs=TRUE)$y
+  y3 <- sim_ode(mod3, parameters = parameters, regimen = reg, covariates = covs, only_obs=TRUE)$y
 
-test_that("bioav numeric option working", {
-  expect_equal(round(y1,1),  round(y2*2, 1))
-})
-
-test_that("bioav string option working", {
   expect_equal(round(y1*(50/70),1),  round(y3, 1))
 })
 

--- a/tests/testthat/test_calc_ss_analytic.R
+++ b/tests/testthat/test_calc_ss_analytic.R
@@ -8,6 +8,9 @@ reg_inf <- new_regimen(amt = dose, interval = interval, n = n_ss, type = "infusi
 t_obs <- max(reg_oral$dose_times) + interval
 # Uses models defined in setup.R
 
+if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+  pk_3cmt_oral <- new_ode_model("pk_3cmt_oral")
+}
 
 #delta <- function(x, ref) { abs(x-ref)/ref }
 
@@ -95,7 +98,6 @@ test_that("2-cmt infusion", {
 
 test_that("3-cmt oral", {
   skip_on_cran()
-  pk_3cmt_oral <- new_ode_model("pk_3cmt_oral")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 250, KA = 1)
   res_ana <- calc_ss_analytic(f = "3cmt_oral", dose = dose, interval = interval, parameters = par)
   res_ode <- sim(pk_3cmt_oral, parameters = par, regimen = reg_oral, t_obs = t_obs, only_obs = F)$y
@@ -105,7 +107,6 @@ test_that("3-cmt oral", {
 
 test_that("3-cmt iv bolus", {
   skip_on_cran()
-  pk_3cmt_iv <- new_ode_model("pk_3cmt_iv")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 250)
   res_ana <- calc_ss_analytic(f = "3cmt_iv_bolus", dose = dose, interval = interval, parameters = par)
   res_ode <- sim(pk_3cmt_iv, parameters = par, regimen = reg_bolus, t_obs = t_obs, only_obs = F)$y

--- a/tests/testthat/test_calc_ss_analytic.R
+++ b/tests/testthat/test_calc_ss_analytic.R
@@ -9,7 +9,7 @@ t_obs <- max(reg_oral$dose_times) + interval
 # Uses models defined in setup.R
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
-  pk_3cmt_oral <- new_ode_model("pk_3cmt_oral")
+  pk_3cmt_iv <- new_ode_model("pk_3cmt_iv")
 }
 
 #delta <- function(x, ref) { abs(x-ref)/ref }
@@ -98,6 +98,7 @@ test_that("2-cmt infusion", {
 
 test_that("3-cmt oral", {
   skip_on_cran()
+  pk_3cmt_oral <- new_ode_model("pk_3cmt_oral")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 250, KA = 1)
   res_ana <- calc_ss_analytic(f = "3cmt_oral", dose = dose, interval = interval, parameters = par)
   res_ode <- sim(pk_3cmt_oral, parameters = par, regimen = reg_oral, t_obs = t_obs, only_obs = F)$y
@@ -116,7 +117,6 @@ test_that("3-cmt iv bolus", {
 
 test_that("3-cmt infusion", {
   skip_on_cran()
-  pk_3cmt_iv <- new_ode_model("pk_3cmt_iv")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 252)
   res_ana <- calc_ss_analytic(f = "3cmt_iv_infusion", dose = dose, interval = interval, parameters = par, t_inf = 1)
   res_ode <- sim(pk_3cmt_iv, parameters = par, regimen = reg_inf, t_obs = t_obs, only_obs = F)$y

--- a/tests/testthat/test_calc_ss_analytic.R
+++ b/tests/testthat/test_calc_ss_analytic.R
@@ -7,9 +7,7 @@ reg_bolus <- new_regimen(amt = dose, interval = interval, n = n_ss, type = "bolu
 reg_inf <- new_regimen(amt = dose, interval = interval, n = n_ss, type = "infusion")
 t_obs <- max(reg_oral$dose_times) + interval
 # Uses models defined in setup.R
-pk_2cmt_oral <- new_ode_model("pk_2cmt_oral")
-pk_3cmt_oral <- new_ode_model("pk_3cmt_oral")
-pk_3cmt_iv <- new_ode_model("pk_3cmt_iv")
+
 
 #delta <- function(x, ref) { abs(x-ref)/ref }
 
@@ -70,6 +68,8 @@ test_that("1-cmt iv infusion", {
 })
 
 test_that("2-cmt oral", {
+  skip_on_cran()
+  pk_2cmt_oral <- new_ode_model("pk_2cmt_oral")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, KA = 1)
   res_ana <- calc_ss_analytic(f = "2cmt_oral", dose = dose, interval = interval, parameters = par)
   res_ode <- sim(pk_2cmt_oral, parameters = par, regimen = reg_oral, t_obs = t_obs, only_obs = F)$y
@@ -94,6 +94,8 @@ test_that("2-cmt infusion", {
 })
 
 test_that("3-cmt oral", {
+  skip_on_cran()
+  pk_3cmt_oral <- new_ode_model("pk_3cmt_oral")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 250, KA = 1)
   res_ana <- calc_ss_analytic(f = "3cmt_oral", dose = dose, interval = interval, parameters = par)
   res_ode <- sim(pk_3cmt_oral, parameters = par, regimen = reg_oral, t_obs = t_obs, only_obs = F)$y
@@ -102,6 +104,8 @@ test_that("3-cmt oral", {
 })
 
 test_that("3-cmt iv bolus", {
+  skip_on_cran()
+  pk_3cmt_iv <- new_ode_model("pk_3cmt_iv")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 250)
   res_ana <- calc_ss_analytic(f = "3cmt_iv_bolus", dose = dose, interval = interval, parameters = par)
   res_ode <- sim(pk_3cmt_iv, parameters = par, regimen = reg_bolus, t_obs = t_obs, only_obs = F)$y
@@ -110,6 +114,8 @@ test_that("3-cmt iv bolus", {
 })
 
 test_that("3-cmt infusion", {
+  skip_on_cran()
+  pk_3cmt_iv <- new_ode_model("pk_3cmt_iv")
   par <- list(CL = 5, V = 100, Q = 3, V2 = 150, Q2 = 6, V3 = 252)
   res_ana <- calc_ss_analytic(f = "3cmt_iv_infusion", dose = dose, interval = interval, parameters = par, t_inf = 1)
   res_ode <- sim(pk_3cmt_iv, parameters = par, regimen = reg_inf, t_obs = t_obs, only_obs = F)$y

--- a/tests/testthat/test_cmt_mapping.R
+++ b/tests/testthat/test_cmt_mapping.R
@@ -28,6 +28,7 @@ test_that("Admin route is interpreted and simulated correctly", {
 })
 
 test_that("multiple scaling types on one compartment works", {
+  skip_on_cran()
   mod <- new_ode_model(
     code = "
       dAdt[1] = -KA * A[1];

--- a/tests/testthat/test_get_var_y.R
+++ b/tests/testthat/test_get_var_y.R
@@ -22,6 +22,7 @@ res <- sim_ode(
 
 ## 1 compartment model
 test_that("delta approximation and full simulation match", {
+  skip_on_cran()
   v_delta <- get_var_y(
     model = mod_1cmt_iv,
     parameters = par,
@@ -45,6 +46,7 @@ test_that("delta approximation and full simulation match", {
 })
 
 test_that("Confidence interval instead of SD", {
+  skip_on_cran()
   CI_range <- c(0.1, 0.9)
   reg2 <- new_regimen(
     amt = 2000,
@@ -88,6 +90,7 @@ test_that("Confidence interval instead of SD", {
 
 
 test_that("Two compartment model", {
+  skip_on_cran()
   set.seed(80)
   # Uses models defined in setup.R
   par2 <- list(CL = 1, V = 10, Q = 1, V2 = 10)
@@ -126,6 +129,7 @@ test_that("Two compartment model", {
 })
 
 test_that("One compartment with MM kinetics", {
+  skip_on_cran()
   mod3 <- new_ode_model("pk_1cmt_iv_mm")
   par3 <- list(VMAX = 5, KM = 5, V = 10)
   omega3 <- c(0.1,

--- a/tests/testthat/test_iov.R
+++ b/tests/testthat/test_iov.R
@@ -1,4 +1,5 @@
 test_that("IOV is added to parameters", {
+  skip_on_cran()
   set.seed(32)
   pars <- list(
     "kappa_CL_1" = 0,

--- a/tests/testthat/test_parameters_table.R
+++ b/tests/testthat/test_parameters_table.R
@@ -1,4 +1,5 @@
 test_that("Simulating with table of parameters works", {
+  skip_on_cran()
   parameters_table <- data.frame(
     CL = rnorm(10, 5, 5),
     V = rnorm(10, 5, 0.5)

--- a/tests/testthat/test_pkpd_combined.R
+++ b/tests/testthat/test_pkpd_combined.R
@@ -1,4 +1,5 @@
 test_that("combined PKPD model compiles", {
+  skip_on_cran()
   pkpd <- new_ode_model(
     code = list(
       pk = "dAdt[1] = -(CL/V) * A[1]; conc = A[1]/V;",

--- a/tests/testthat/test_t_init.R
+++ b/tests/testthat/test_t_init.R
@@ -5,6 +5,7 @@
 ## Use this as true value in the simulations
 
 test_that("TDM before first dose is considered a true initial value", {
+  skip_on_cran()
   par   <- list(CL = 7.67, V = 97.7, TDM_INIT = 500)
   mod <- new_ode_model(
     code = "dAdt[1] = -(CL/V)*A[1];",

--- a/tests/testthat/test_timevar_cov.R
+++ b/tests/testthat/test_timevar_cov.R
@@ -1,4 +1,5 @@
 test_that("timevarying covariates handled", {
+  skip_on_cran()
   # CLi changes by several orders of magnitude after
   # steady state is achieved, which should produce
   # a new steady state that is much lower


### PR DESCRIPTION
Some of our tests are relatively slow, often due to calls to `new_ode_model()`. This skips some tests on CRAN and rearranges some of the test code to put it within `test_that()` calls (so it can be easily skipped). In `test_advan_with_auc.R` there's a lot of code outside of `test_that()` calls that gets reused in multiple tests, so rather than duplicate it I put it in an `if` clause that checks for the `NOT_CRAN` environment variable. This is the same approach taken by `skip_on_cran()`, so I think it should be reasonable.

On my machine, `devtools::check(env_vars = c("NOT_CRAN" = "false"))` reports that the test suite takes 54 seconds. It's possible results will be different on CRAN machines depending on their load, but there's no real way to be certain until we try, so I think this is good enough for now. 