### PR TITLE
RXR-636: CRAN submission prep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PKPDsim
 Type: Package
-Title: Simulate Ordinary Differential Equations for Pharmacokinetic Models
+Title: Simulate Ordinary Differential Equations for Pharmacokinetic-Pharmacodynamic Models
 Version: 1.0.124
 Date: 2021-12-06
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PKPDsim
 Type: Package
-Title: Simulate ODE Models
+Title: Simulate Ordinary Differential Equations for Pharmacokinetic Models
 Version: 1.0.124
 Date: 2021-12-06
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,9 @@ Imports: Rcpp (>= 0.12.9), BH, data.table, lubridate, stringr, MASS,
         randtoolbox, jsonlite, stats, parallel, magrittr
 Suggests: httr, testthat (>= 3.0.0)
 LinkingTo: BH, Rcpp (>= 0.12.9)
-Description: Simulate dose regimens for PKPD models described by DE
-        systems or analytical equations.
+Description: Simulate dose regimens for pharmacokinetic-pharmacodynamic (PK-PD)
+        models described by differential equation (DE) systems or analytical
+        equations.
 License: MIT + file LICENSE
 LazyData: TRUE
 RoxygenNote: 7.1.2

--- a/R/add_ruv.R
+++ b/R/add_ruv.R
@@ -5,6 +5,7 @@
 #' @param obs_type vector of observation types
 #'
 #' @export
+#' @return Input vector with residual variability added
 add_ruv <- function(x, ruv = list(), obs_type = 1) {
   if(!is.null(ruv$prop)) {
     x <- x * (1 + stats::rnorm(length(x), 0, ruv$prop[obs_type]))

--- a/R/add_ruv_to_quantile.R
+++ b/R/add_ruv_to_quantile.R
@@ -8,6 +8,7 @@
 #' @param ... passed arguments
 #' 
 #' @export
+#' @return Numeric vector of y values with residual variability
 add_ruv_to_quantile <- function(
   y,
   sd_y,

--- a/R/adherence.R
+++ b/R/adherence.R
@@ -13,6 +13,7 @@
 #' @return Returns a vector of length `n`
 #'   containing values 0 (non-adherent) or 1 (adherent).
 #' @export
+#' @return Numeric vector of length n
 new_adherence <- function(n = 100,
                           type = c("markov", "binomial"),
                           p_markov_remain_ad = 0.75,
@@ -38,6 +39,7 @@ new_adherence <- function(n = 100,
 #' @return Returns a vector of length `n`
 #'   containing values 0 (non-adherent) or 1 (adherent).
 #' @export
+#' @return Numeric vector of length n
 adherence_markov <- function(n = 100, p11 = 0.9, p01 = 0.7) {
   adh <- 1
   dos <- 1 # all patients adherent for first dose
@@ -64,6 +66,7 @@ adherence_markov <- function(n = 100, p11 = 0.9, p01 = 0.7) {
 #' @return Returns a vector of length `n`
 #'   containing values 0 (non-adherent) or 1 (adherent).
 #' @export
+#' @return Numeric vector of length n
 adherence_binomial <- function(n = 100, prob) {
   stats::rbinom(n, 1, prob)
 }

--- a/R/advan.R
+++ b/R/advan.R
@@ -703,6 +703,7 @@ ThreeCompOralMetab <- function(d) {
 #' @param model Standard linear PK model, e.g. `pk_1cmt_iv_bolus`.
 #' @param cpp use C++-versions of model (~50x faster than R implementations)
 #' @export
+#' @return Model function
 advan <- function(model, cpp = TRUE) {
   cmt <- list(
     "1cmt_iv_bolus" = 1,

--- a/R/advan_create_data.R
+++ b/R/advan_create_data.R
@@ -8,6 +8,7 @@
 #' @param covariate_model covariate model equations, written in C
 #'
 #' @export
+#' @return Data frame of ADVAN-style data
 advan_create_data <- function(
   regimen,
   parameters,

--- a/R/advan_parse_output.R
+++ b/R/advan_parse_output.R
@@ -7,7 +7,7 @@
 #' @param regimen PKPDsim regimen
 #'
 #' @export
-#' @return Data frame containin parsed simulation data
+#' @return Data frame containing parsed simulation data
 advan_parse_output <- function(
   data,
   cmts = 1,

--- a/R/advan_parse_output.R
+++ b/R/advan_parse_output.R
@@ -7,6 +7,7 @@
 #' @param regimen PKPDsim regimen
 #'
 #' @export
+#' @return Data frame containin parsed simulation data
 advan_parse_output <- function(
   data,
   cmts = 1,

--- a/R/advan_process_infusion_doses.R
+++ b/R/advan_process_infusion_doses.R
@@ -8,6 +8,7 @@
 #'   ADVAN-style analytical solutions for common pharmacokinetic models. J
 #'   Pharmacol Toxicol Methods 73:42-8. DOI: 10.1016/j.vascn.2015.03.004
 #' @export
+#' @return Data frame containing additional RATEALL column.
 advan_process_infusion_doses <- function (data) {
 
   # Calculate all amounts

--- a/R/apply_lagtime.R
+++ b/R/apply_lagtime.R
@@ -6,6 +6,7 @@
 #' @param cmt_mapping map of administration types to compartments, e.g. `list("oral" = 1, "infusion" = 2, "bolus" = 2)`.
 #'
 #' @export
+#' @return Original regimen with lagtime added
 apply_lagtime <- function(
   regimen,
   lagtime,

--- a/R/apply_lagtime.R
+++ b/R/apply_lagtime.R
@@ -6,7 +6,7 @@
 #' @param cmt_mapping map of administration types to compartments, e.g. `list("oral" = 1, "infusion" = 2, "bolus" = 2)`.
 #'
 #' @export
-#' @return Original regimen with lagtime added
+#' @return Original regimen with lagtime added to dose times
 apply_lagtime <- function(
   regimen,
   lagtime,

--- a/R/calc_ss_analytic.R
+++ b/R/calc_ss_analytic.R
@@ -21,6 +21,7 @@
 #' @param auc add (empty) AUC compartment at end of state vector?
 #'
 #' @export
+#' @return State vector of a linear pharmacokinetic system at steady state
 calc_ss_analytic <- function(
   f = "1cmt_oral",
   dose,

--- a/R/calculate_parameters.R
+++ b/R/calculate_parameters.R
@@ -13,6 +13,7 @@
 #' @param include_variables boolean, include variables?
 #' @param ... arguments to pass on to simulation function
 #' @export
+#' @return List of model-specific variables
 calculate_parameters <- function(
   ode = NULL,
   parameters = NULL,

--- a/R/compile_sim_cpp.R
+++ b/R/compile_sim_cpp.R
@@ -1,4 +1,5 @@
 #' Compile ODE model to c++ function
+#'
 #' @param code C++ code ODE system
 #' @param dose_code C++ code per dose event
 #' @param pk_code C++ code per any event (similar to $PK)
@@ -17,6 +18,7 @@
 #' @param verbose show more output
 #' @param as_is use C-code as-is, don't substitute line-endings or shift indices
 #' @export
+#' @return List containing ODE definition in C++ code and simulation function
 compile_sim_cpp <- function(
   code,
   dose_code,

--- a/R/covariate_last_obs_only.R
+++ b/R/covariate_last_obs_only.R
@@ -2,7 +2,7 @@
 #'
 #' @param covariates covariates object
 #' @export
-#' @return Final covariate from the covariates object
+#' @return List containing same elements as input covariate object but including only the last value for each covariate
 covariate_last_obs_only <- function(covariates) {
   for(lab in names(covariates)) {
     covariates[[lab]]$value <- utils::tail(covariates[[lab]]$value, 1)

--- a/R/covariate_last_obs_only.R
+++ b/R/covariate_last_obs_only.R
@@ -2,6 +2,7 @@
 #'
 #' @param covariates covariates object
 #' @export
+#' @return Final covariate from the covariates object
 covariate_last_obs_only <- function(covariates) {
   for(lab in names(covariates)) {
     covariates[[lab]]$value <- utils::tail(covariates[[lab]]$value, 1)

--- a/R/covariates_table_to_list.R
+++ b/R/covariates_table_to_list.R
@@ -1,9 +1,11 @@
 #' Convert covariate table specified as data.frame
+#'
 #' Can handle time-varying data too, if `t` or `time` is specified as column
 #'
 #' @param covariates_table `data.frame`` with covariates in columns. Potentially with `id` and `t` columns
 #' @param covariates_implementation `list` with implementation method per covariate
 #' @export
+#' @return List of covariates
 covariates_table_to_list <- function(covariates_table, covariates_implementation = list()) {
   covs_obj <- list()
   names(covariates_table)[names(covariates_table) == "ID"] <- "id" # NONMEM syntax

--- a/R/detect_ode_syntax.R
+++ b/R/detect_ode_syntax.R
@@ -4,6 +4,9 @@
 #'
 #' @param code character string with ODE code
 #' @export
+#' @return List with elements `from` and `to` indicating the syntax for the ODE
+#'   code
+#' @md
 detect_ode_syntax <- function(code) {
   ## currently very simple, supports only PKPDsim / RxODE
   from <- "PKPDsim"

--- a/R/get_ode_model_size.R
+++ b/R/get_ode_model_size.R
@@ -2,6 +2,7 @@
 #' code C++ code for model
 #' @param code C++ code
 #' @export
+#' @return Number of states in the ODE model
 get_ode_model_size <- function(code) {
   m <- gregexpr("\\[([0-9]*)\\]", code)
   m1 <- unlist(regmatches(code, m))

--- a/R/get_parameters_from_code.R
+++ b/R/get_parameters_from_code.R
@@ -3,6 +3,7 @@
 #' @param state_init state init vector
 #' @param declare_variables declared variables
 #' @export
+#' @return Vector of parameter names
 get_parameters_from_code <- function (code, state_init, declare_variables = NULL) {
   ## find newly defined parameters in code
   if(!is.null(state_init)) {

--- a/R/get_var_y.R
+++ b/R/get_var_y.R
@@ -24,7 +24,7 @@
 #' @param ... passed on to `sim_ode()`
 #'
 #' @export
-#' @return Standard deviation or variance (or quantiles thereof) for dependent
+#' @return Vector of standard deviations or variances (or quantiles thereof) for dependent value
 #'   variable
 get_var_y <- function(
   model = NULL,

--- a/R/get_var_y.R
+++ b/R/get_var_y.R
@@ -24,6 +24,8 @@
 #' @param ... passed on to `sim_ode()`
 #'
 #' @export
+#' @return Standard deviation or variance (or quantiles thereof) for dependent
+#'   variable
 get_var_y <- function(
   model = NULL,
   parameters = list(),

--- a/R/ifelse0.R
+++ b/R/ifelse0.R
@@ -5,6 +5,8 @@
 #' @param allow_null can the alternative be NULL?
 #'
 #' @export
+#' @return `value` if non-NULL; `alternative` otherwise
+#' @md
 ifelse0 <- function(value = NULL, alternative = NULL, allow_null = FALSE) {
   if(is.null(alternative) && !allow_null) {
     stop("No alternative specified")

--- a/R/is_positive_definite.R
+++ b/R/is_positive_definite.R
@@ -2,6 +2,8 @@
 #'
 #' @param x matrix, specified either as `vector` of lower triangle, or full matrix (as `matrix` class)
 #' @export
+#' @return TRUE if `x` is positive definite; FALSE otherwise.
+#' @md
 is_positive_definite <- function(x) {
   if(! "matrix" %in% class(x)) x <- triangle_to_full(x)
   eig <- eigen(x, only.values = TRUE)

--- a/R/join_cov_and_par.R
+++ b/R/join_cov_and_par.R
@@ -4,7 +4,7 @@
 #' @param pars model parameters, such as the output of the `parameters()` call frmo a model library.
 #'
 #' @export
-
+#' @return List containing covariates and parameters
 join_cov_and_par <- function(covs, pars){
   c(pars, lapply(covs, `[[`, "value"))
 }

--- a/R/join_regimen.R
+++ b/R/join_regimen.R
@@ -7,6 +7,7 @@
 #' @param t_dose_update dose time from which to update regimen
 #' @param continuous for joining continuous infusions
 #' @export
+#' @return Joined regimen
 join_regimen <- function(
   regimen1 = NULL,
   regimen2 = NULL,

--- a/R/merge_regimen.R
+++ b/R/merge_regimen.R
@@ -6,6 +6,7 @@
 #' @param regimens List of PKPDsim regimens created with `new_regimen`.
 #'
 #' @export
+#' @return Merged regimens
 merge_regimen <- function(regimens) {
   cols <- c("interval", "n", "type", "t_inf", "dose_times", "dose_amts", "first_dose_time")
   reg <- data.frame(regimens[[1]], stringsAsFactors = FALSE)[, cols]

--- a/R/misc.R
+++ b/R/misc.R
@@ -3,6 +3,7 @@
 #' @param ... parameters to pass to cov
 #'
 #' @export
+#' @return Covariate function
 f_cov <- function (...) {
   substitute( with(cov, { ... } ) )
 }
@@ -39,6 +40,7 @@ cleanup_code <- function(code) {
 #' @param find find what string, vector of character
 #' @param replacement replace with what, vector of character, should be equal in lenght to `find`
 #' @export
+#' @return Function does not return a value but edits files on disk
 search_replace_in_file <- function(files = c(), find = NULL, replacement = NULL) {
   for(file in files) {
     x <- readLines(file)
@@ -58,6 +60,7 @@ search_replace_in_file <- function(files = c(), find = NULL, replacement = NULL)
 #' @param x vector of string / numeric
 #' @param quote what type of quotes (`double` or `single`)
 #' @export
+#' @return Character vector of input with quotation marks around each value
 add_quotes <- function(x, quote = "double") {
   q <- '"'
   if(quote == "single") {
@@ -75,6 +78,7 @@ add_quotes <- function(x, quote = "double") {
 #' @param wrapper wrap in list object?
 #' @param quote add quotes to values in list definition?
 #' @export
+#' @return Original list in R syntax
 print_list <- function(x, wrapper = TRUE, quote = FALSE) {
   if(is.null(x)) return("")
   if(!quote) {

--- a/R/model_from_api.R
+++ b/R/model_from_api.R
@@ -10,6 +10,8 @@
 #' @param install_all force install all, even if model inactive
 #' @param ... arguments passed to `new_ode_model()` function
 #' @export
+#' @return Model object created with [PKPDsim::new_ode_model()]
+#' @md
 model_from_api <- function(url,
                            model = NULL,
                            nonmem = NULL,

--- a/R/model_library.R
+++ b/R/model_library.R
@@ -1,6 +1,7 @@
 #' Model library
 #' @param name name of model in library. If none specified, will show list of available models.
 #' @export
+#' @return List containing information about the named model
 model_library <- function(name = NULL) {
   lib <- list(
     "pk_1cmt_iv" = list(

--- a/R/mvrnorm2.R
+++ b/R/mvrnorm2.R
@@ -1,6 +1,6 @@
 #' More powerful multivariate normal sampling function
 #'
-#' Besides standard mutlivariate normal sampling (mvrnorm), allows exponential
+#' Besides standard multivariate normal sampling (mvrnorm), allows exponential
 #' multivarate normal and quasi-random multivariate normal (using the randtoolbox)
 #' all using the same interface.
 #'
@@ -11,6 +11,7 @@
 #' @param sequence any sequence available in the randtoolbox, e.g. `halton`, or `sobol`
 #' @param ... parameters passed to mvrnorm or randtoolbox sequence generator
 #' @export
+#' @return Multivariate normal samples
 mvrnorm2 <- function(n, mu, Sigma, exponential = FALSE, sequence = NULL, ...) {
   if(!is.null(sequence)) {
     func <- getExportedValue('randtoolbox', sequence)

--- a/R/na_locf.R
+++ b/R/na_locf.R
@@ -7,7 +7,7 @@
 #'   than forward. Default is FALSE.
 #'
 #' @export
-#' @return Original object iwth NAs filled in
+#' @return Original object with NAs filled in
 na_locf <- function(object, fromLast = FALSE) {
   if (fromLast) object <- rev(object)
   for (i in seq_along(object)) {

--- a/R/na_locf.R
+++ b/R/na_locf.R
@@ -3,9 +3,11 @@
 #' Inspired by zoo::na.locf0
 #'
 #' @param object an object
-#' @param fromLast logical. Causes observations to be carried backward rather than forward. Default is FALSE. With a value of TRUE this corresponds to NOCB (next observation carried backward). It is not supported if x or xout is specified.
+#' @param fromLast logical. Causes observations to be carried backward rather
+#'   than forward. Default is FALSE.
 #'
 #' @export
+#' @return Original object iwth NAs filled in
 na_locf <- function(object, fromLast = FALSE) {
   if (fromLast) object <- rev(object)
   for (i in seq_along(object)) {

--- a/R/new_covariate.R
+++ b/R/new_covariate.R
@@ -10,6 +10,8 @@
 #' @param comments `NULL`, or vector of length equal to `value` specifying comments to each observation
 #' @param verbose verbosity
 #' @export
+#' @return Object of class `"covariate"
+#' @md
 new_covariate <- function(
   value = NULL,
   times = NULL,

--- a/R/new_covariate.R
+++ b/R/new_covariate.R
@@ -10,7 +10,7 @@
 #' @param comments `NULL`, or vector of length equal to `value` specifying comments to each observation
 #' @param verbose verbosity
 #' @export
-#' @return Object of class `"covariate"
+#' @return Object of class `"covariate"`
 #' @md
 new_covariate <- function(
   value = NULL,

--- a/R/new_covariate_model.R
+++ b/R/new_covariate_model.R
@@ -3,6 +3,7 @@
 #' @param model covariate model specified as list
 #'
 #' @export
+#' @return List containing model function(s)
 new_covariate_model <- function(model = list()) {
   new_model <- list()
   for (i in seq(names(model))) {

--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -42,6 +42,8 @@
 #' output cmd line output. Default (`""`) is R console, NULL or FALSE discards.
 #' TRUE captures the output and saves as a file.
 #' @export
+#' @return If package name is NULL, returns the model object. Otherwise has no
+#'   return value.
 new_ode_model <- function (model = NULL,
                            code = NULL,
                            pk_code = NULL,

--- a/R/nlmixr_parse_parameters.R
+++ b/R/nlmixr_parse_parameters.R
@@ -7,6 +7,7 @@
 #' @param log_transform log-transform estimated parameters in nlmixr?
 #' @param ... passed on
 #' @export
+#' @return List of parameters that can be used by nlmixr
 nlmixr_parse_parameters <- function(
   parameters = list(CL = 5, V = 50),
   omega = c(0.1, 0.05, 0.1),

--- a/R/nm_to_regimen.R
+++ b/R/nm_to_regimen.R
@@ -1,10 +1,11 @@
-#' Create a regimen from NM data
+#' Create a regimen from NONMEM data
 #'
 #' Create a regimen based on a NONMEM, or NONMEM-like dataset
 #' @param data NONMEM-type dataset
 #' @param reset_time start time for each simulated patient at 0, irrespective of design in dataset
 #' @param first_only use only design from first individual in dataset
 #' @export
+#' @return Regimen object
 nm_to_regimen <- function(data,
                           reset_time = TRUE,
                           first_only = FALSE) {

--- a/R/pkpdsim_to_nlmixr.R
+++ b/R/pkpdsim_to_nlmixr.R
@@ -11,6 +11,7 @@
 #' @param verbose verbose, `TRUE` or `FALSE`
 #' @param ... passed on
 #' @export
+#' @return nlmixr function
 pkpdsim_to_nlmixr <- function(
   model = NULL,
   parameters = NULL,

--- a/R/pop_regimen.R
+++ b/R/pop_regimen.R
@@ -1,10 +1,13 @@
 #' Remove n doses (from tail) of PKPDsim regimen
+#'
 #' Opposite of shift_regimen()
 #'
 #' @param regimen PKPDsim regimen created using `new_regimen()`
 #' @param n number of doses to pop from regimen
 #'
+#' @seealso shift_regimen
 #' @export
+#' @return Input regiment minus selected number of doses
 pop_regimen <- function(
     regimen,
     n = 1) {

--- a/R/read_model_json.R
+++ b/R/read_model_json.R
@@ -6,6 +6,7 @@
 #' @param path Path to JSON file
 #' @md
 #' @export
+#' @return List containing contents of original JSON file
 read_model_json <- function(path) {
   lines <- paste(readLines(path), collapse = "\n") %>%
     stringr::str_replace_all("'", "\"") %>%

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -7,6 +7,7 @@
 #' @param obs_cmt observation compartment for added observation time(s)
 #'
 #' @export
+#' @return Data frame containing doses
 regimen_to_nm <- function(
   reg = NULL,
   dose_cmt = 1,

--- a/R/reparametrize.R
+++ b/R/reparametrize.R
@@ -8,6 +8,7 @@
 #' @param covariates covariates list, specified as PKPDsim covariates
 #'
 #' @export
+#' @return Reparameterized model parameters
 reparametrize <- function(model, parameters, covariates) {
   reparametrization <- attr(model, "reparametrization")
   if(is.null(reparametrization)) {

--- a/R/shift_regimen.R
+++ b/R/shift_regimen.R
@@ -1,11 +1,14 @@
 #' Remove n doses (from start) of PKPDsim regimen
+#'
 #' Opposite of pop_regimen()
 #' 
 #' @param regimen PKPDsim regimen created using `new_regimen()`
 #' @param n number of doses to shift regimen
 #' @param reset_time reset the remaining doses to start at t=0?
 #'
+#' @seealso pop_regimen
 #' @export
+#' @return Regimen with selected number of doses removed from start
 shift_regimen <- function(
     regimen,
     n = 1,

--- a/R/sim.R
+++ b/R/sim.R
@@ -43,44 +43,54 @@
 #' @seealso \link{sim_ode_shiny}
 #' @examples
 #' \dontrun{
-#'library(ggplot2)
-#'library(PKPDsim)
-#'p <- list(CL = 38.48,
-#'          V  = 7.4,
-#'          Q  = 7.844,
-#'          V2 = 5.19,
-#'          Q2  = 9.324,
-#'          V3 = 111)
+#' p <- list(
+#'   CL = 38.48,
+#'   V  = 7.4,
+#'   Q  = 7.844,
+#'   V2 = 5.19,
+#'   Q2  = 9.324,
+#'   V3 = 111
+#' )
 #'
-#'r1 <- new_regimen(amt = 100,
-#'              times = c(0, 24, 36),
-#'              type = "infusion")
+#' r1 <- new_regimen(
+#'   amt = 100,
+#'   times = c(0, 24, 36),
+#'   type = "infusion"
+#' )
 #'
-#'mod <- new_ode_model("pk_3cmt_iv")
-#'dat <- sim(ode = mod,
-#'           parameters = p,
-#'           regimen = r1)
+#' mod <- new_ode_model("pk_3cmt_iv")
+#' dat <- sim(
+#'   ode = mod,
+#'   parameters = p,
+#'   regimen = r1
+#' )
 #'
-#'ggplot(dat, aes(x=t, y=y)) +
-#'  geom_line() +
-#'  scale_y_log10() +
-#'  facet_wrap(~comp)
+#' dat_wide <- reshape(
+#'   dat,
+#'   direction = "wide",
+#'   timevar = "comp",
+#'   idvar = "t"
+#' )
 #'
-#'# repeat with IIV:
-#'omega <- c(0.3,       # IIV CL
-#'           0.1, 0.3)  # IIV V
+#' matplot(
+#'   dat_wide[, grepl("^y", names(dat_wide))],
+#'   type = "b",
+#'   pch = 1,
+#'   log = "y"
+#' )
 #'
-#'dat <- sim (ode = mod,
-#'            parameters = p,
-#'            omega = omega,
-#'            n_ind = 20,
-#'            regimen = r1)
+#' # repeat with IIV:
+#' omega <- c(0.3,       # IIV CL
+#'            0.1, 0.3)  # IIV V
 #'
-#'ggplot(dat, aes(x=t, y=y, colour=factor(id), group=id)) +
-#'  geom_line() +
-#'  scale_y_log10() +
-#'  facet_wrap(~comp)
-#'}
+#' dat <- sim(
+#'   ode = mod,
+#'   parameters = p,
+#'   omega = omega,
+#'   n_ind = 20,
+#'   regimen = r1
+#' )
+#' }
 sim <- function (ode = NULL,
                  analytical = NULL,
                  parameters = NULL,

--- a/R/sim.R
+++ b/R/sim.R
@@ -1,6 +1,7 @@
 #' Simulate ODE or analytical equation
 #'
 #' Simulates a specified regimen using ODE system or analytical equation
+#'
 #' @param ode function describing the ODE system
 #' @param analytical string specifying analytical equation model to use (similar to ADVAN1-5 in NONMEM). If specified, will not use ODEs.
 #' @param parameters model parameters
@@ -41,6 +42,7 @@
 #' @return a data frame of compartments with associated concentrations at requested times
 #' @export
 #' @seealso \link{sim_ode_shiny}
+#' @return Simulated regimen
 #' @examples
 #' \dontrun{
 #' p <- list(

--- a/R/sim_core.R
+++ b/R/sim_core.R
@@ -6,7 +6,7 @@
 #' @param duplicate_t_obs allow duplicate t_obs in output? E.g. for optimal design calculations when t_obs = c(0,1,2,2,3). Default is FALSE.
 #' @param t_init time of initization of the ODE system. Usually 0.
 #' @export
-#' @return Data frame of observations
+#' @return Data frame with simulation results
 sim_core <- function(
   sim_object = NULL,
   ode,

--- a/R/sim_core.R
+++ b/R/sim_core.R
@@ -6,6 +6,7 @@
 #' @param duplicate_t_obs allow duplicate t_obs in output? E.g. for optimal design calculations when t_obs = c(0,1,2,2,3). Default is FALSE.
 #' @param t_init time of initization of the ODE system. Usually 0.
 #' @export
+#' @return Data frame of observations
 sim_core <- function(
   sim_object = NULL,
   ode,

--- a/R/sim_ode.R
+++ b/R/sim_ode.R
@@ -2,6 +2,9 @@
 #'
 #' @param ... parameters passed to `sim()` function
 #' @export
+#' @seealso sim
+#' @return Output from [sim()]
+#' @md
 sim_ode <- function(...) {
 #  .Deprecated("sim")
   sim(...)

--- a/R/sim_ode_shiny.R
+++ b/R/sim_ode_shiny.R
@@ -1,9 +1,12 @@
 #' Simulate ODE and create a Shiny app
 #'
+#' This function has been deprecated and moved to a separate package at
+#' https://github.com/ronkeizer/PKPDsimshiny.
+#'
 #' @param ... arguments passed to PKPDsimShiny::sim_ode_shiny()
 #' @export
 #' @seealso \link{sim_ode}
-
+#' @return No return value
 sim_ode_shiny <- function(...) {
 #   if("PKPDsimShiny" %in% rownames(installed.packages())) {
 #     PKPDsimShiny::sim_ode_shiny(...)

--- a/R/table_to_list.R
+++ b/R/table_to_list.R
@@ -2,6 +2,7 @@
 #'
 #' @param table data.frame
 #' @export
+#' @return List containing original table contents
 table_to_list <- function(table) {
   lapply(split(table, seq_along(table[,1])), as.list)
 }

--- a/R/test_model.R
+++ b/R/test_model.R
@@ -6,6 +6,7 @@
 #' @param force Run tests even if model is not flagged for building? Defaults to
 #'   FALSE
 #' @export
+#' @return Runs test file for a model but does not return a value
 test_model <- function(url, test_file, package, force = FALSE) {
   def <- read_model_json(url)
   if (isTRUE(def$build) || isTRUE(force)) {

--- a/R/test_pointer.R
+++ b/R/test_pointer.R
@@ -1,6 +1,7 @@
 #' Test if model still in memory
 #' @param model pointer to model
 #' @export
+#' @return No return value
 test_pointer <- function(model) {
   tmp <- utils::capture.output(model)
   if(length(grep("0x0>", tmp[2])) > 0) {

--- a/R/translate_ode.R
+++ b/R/translate_ode.R
@@ -8,6 +8,7 @@
 #' @param to to syntax
 #' @param verbose verbose, `TRUE` or `FALSE`
 #' @export
+#' @return Translated PKPDsim or RxODE model
 translate_ode <- function(
   code,
   auto = TRUE,

--- a/R/triangle_to_full.R
+++ b/R/triangle_to_full.R
@@ -2,6 +2,7 @@
 #'
 #' @param vect vector specifying triangle omega matrix
 #' @export
+#' @return Omega matrix
 triangle_to_full <- function (vect) {
   lower_triangle_mat_size <- function (mat) {
     x <- length(mat)

--- a/man/add_quotes.Rd
+++ b/man/add_quotes.Rd
@@ -11,6 +11,9 @@ add_quotes(x, quote = "double")
 
 \item{quote}{what type of quotes (`double` or `single`)}
 }
+\value{
+Character vector of input with quotation marks around each value
+}
 \description{
 Put vector values in quotes
 }

--- a/man/add_ruv.Rd
+++ b/man/add_ruv.Rd
@@ -13,6 +13,9 @@ add_ruv(x, ruv = list(), obs_type = 1)
 
 \item{obs_type}{vector of observation types}
 }
+\value{
+Input vector with residual variability added
+}
 \description{
 Add residual variability to the dependent variable
 }

--- a/man/add_ruv_to_quantile.Rd
+++ b/man/add_ruv_to_quantile.Rd
@@ -19,6 +19,9 @@ add_ruv_to_quantile(y, sd_y, log_scale = FALSE, q = NULL, ruv = list(), ...)
 
 \item{...}{passed arguments}
 }
+\value{
+Numeric vector of y values with residual variability
+}
 \description{
 Calculate the increase in a specific quantile for a distribution on y when residual variability is added
 }

--- a/man/adherence_binomial.Rd
+++ b/man/adherence_binomial.Rd
@@ -14,6 +14,8 @@ adherence_binomial(n = 100, prob)
 \value{
 Returns a vector of length `n`
   containing values 0 (non-adherent) or 1 (adherent).
+
+Numeric vector of length n
 }
 \description{
 Model adherence as a binomial probability at the time of each occasion.

--- a/man/adherence_markov.Rd
+++ b/man/adherence_markov.Rd
@@ -16,6 +16,8 @@ adherence_markov(n = 100, p11 = 0.9, p01 = 0.7)
 \value{
 Returns a vector of length `n`
   containing values 0 (non-adherent) or 1 (adherent).
+
+Numeric vector of length n
 }
 \description{
 Model adherence as a markov chain model, based on the probability of staying

--- a/man/advan.Rd
+++ b/man/advan.Rd
@@ -11,6 +11,9 @@ advan(model, cpp = TRUE)
 
 \item{cpp}{use C++-versions of model (~50x faster than R implementations)}
 }
+\value{
+Model function
+}
 \description{
 ADVAN-style functions to calculate linear PK systems
 }

--- a/man/advan_create_data.Rd
+++ b/man/advan_create_data.Rd
@@ -26,6 +26,9 @@ advan_create_data(
 
 \item{covariate_model}{covariate model equations, written in C}
 }
+\value{
+Data frame of ADVAN-style data
+}
 \description{
 Create ADVAN-style dataset
 }

--- a/man/advan_parse_output.Rd
+++ b/man/advan_parse_output.Rd
@@ -18,7 +18,7 @@ advan_parse_output(data, cmts = 1, t_obs, extra_t_obs = TRUE, regimen)
 \item{regimen}{PKPDsim regimen}
 }
 \value{
-Data frame containin parsed simulation data
+Data frame containing parsed simulation data
 }
 \description{
 Internal function to parse the raw output from ADVAN-style functions

--- a/man/advan_parse_output.Rd
+++ b/man/advan_parse_output.Rd
@@ -17,6 +17,9 @@ advan_parse_output(data, cmts = 1, t_obs, extra_t_obs = TRUE, regimen)
 
 \item{regimen}{PKPDsim regimen}
 }
+\value{
+Data frame containin parsed simulation data
+}
 \description{
 Internal function to parse the raw output from ADVAN-style functions
 }

--- a/man/advan_process_infusion_doses.Rd
+++ b/man/advan_process_infusion_doses.Rd
@@ -9,6 +9,9 @@ advan_process_infusion_doses(data)
 \arguments{
 \item{data}{ADVAN-style dataset, e.g. created using `advan_create_data`.}
 }
+\value{
+Data frame containing additional RATEALL column.
+}
 \description{
 Function adapted from code from Abuhelwa, Foster, Upton JPET 2015.
 cleaned up and somewhat optimized. Can potentially be optimized more.

--- a/man/apply_lagtime.Rd
+++ b/man/apply_lagtime.Rd
@@ -16,7 +16,7 @@ apply_lagtime(regimen, lagtime, parameters, cmt_mapping = NULL)
 \item{cmt_mapping}{map of administration types to compartments, e.g. `list("oral" = 1, "infusion" = 2, "bolus" = 2)`.}
 }
 \value{
-Original regimen with lagtime added
+Original regimen with lagtime added to dose times
 }
 \description{
 Apply lagtime to a regimen

--- a/man/apply_lagtime.Rd
+++ b/man/apply_lagtime.Rd
@@ -15,6 +15,9 @@ apply_lagtime(regimen, lagtime, parameters, cmt_mapping = NULL)
 
 \item{cmt_mapping}{map of administration types to compartments, e.g. `list("oral" = 1, "infusion" = 2, "bolus" = 2)`.}
 }
+\value{
+Original regimen with lagtime added
+}
 \description{
 Apply lagtime to a regimen
 }

--- a/man/calc_ss_analytic.Rd
+++ b/man/calc_ss_analytic.Rd
@@ -42,6 +42,9 @@ calc_ss_analytic(
 
 \item{auc}{add (empty) AUC compartment at end of state vector?}
 }
+\value{
+State vector of a linear pharmacokinetic system at steady state
+}
 \description{
 Basically it performs a PK simulation using analytic equations instead
 of ODEs to steady state (n=45 days, increased if needed).

--- a/man/calculate_parameters.Rd
+++ b/man/calculate_parameters.Rd
@@ -26,6 +26,9 @@ calculate_parameters(
 
 \item{...}{arguments to pass on to simulation function}
 }
+\value{
+List of model-specific variables
+}
 \description{
 This is a convenience function for PKPDsim users, it is not used inside the `sim_ode()``
 function in any way.

--- a/man/compile_sim_cpp.Rd
+++ b/man/compile_sim_cpp.Rd
@@ -59,6 +59,9 @@ compile_sim_cpp(
 
 \item{as_is}{use C-code as-is, don't substitute line-endings or shift indices}
 }
+\value{
+List containing ODE definition in C++ code and simulation function
+}
 \description{
 Compile ODE model to c++ function
 }

--- a/man/covariate_last_obs_only.Rd
+++ b/man/covariate_last_obs_only.Rd
@@ -10,7 +10,7 @@ covariate_last_obs_only(covariates)
 \item{covariates}{covariates object}
 }
 \value{
-Final covariate from the covariates object
+List containing same elements as input covariate object but including only the last value for each covariate
 }
 \description{
 Use only last observed covariate values

--- a/man/covariate_last_obs_only.Rd
+++ b/man/covariate_last_obs_only.Rd
@@ -9,6 +9,9 @@ covariate_last_obs_only(covariates)
 \arguments{
 \item{covariates}{covariates object}
 }
+\value{
+Final covariate from the covariates object
+}
 \description{
 Use only last observed covariate values
 }

--- a/man/covariates_table_to_list.Rd
+++ b/man/covariates_table_to_list.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/covariates_table_to_list.R
 \name{covariates_table_to_list}
 \alias{covariates_table_to_list}
-\title{Convert covariate table specified as data.frame
-Can handle time-varying data too, if `t` or `time` is specified as column}
+\title{Convert covariate table specified as data.frame}
 \usage{
 covariates_table_to_list(covariates_table, covariates_implementation = list())
 }
@@ -12,7 +11,9 @@ covariates_table_to_list(covariates_table, covariates_implementation = list())
 
 \item{covariates_implementation}{`list` with implementation method per covariate}
 }
+\value{
+List of covariates
+}
 \description{
-Convert covariate table specified as data.frame
 Can handle time-varying data too, if `t` or `time` is specified as column
 }

--- a/man/detect_ode_syntax.Rd
+++ b/man/detect_ode_syntax.Rd
@@ -9,6 +9,10 @@ detect_ode_syntax(code)
 \arguments{
 \item{code}{character string with ODE code}
 }
+\value{
+List with elements \code{from} and \code{to} indicating the syntax for the ODE
+code
+}
 \description{
 Either PKPDsim or RxODE
 }

--- a/man/f_cov.Rd
+++ b/man/f_cov.Rd
@@ -9,6 +9,9 @@ f_cov(...)
 \arguments{
 \item{...}{parameters to pass to cov}
 }
+\value{
+Covariate function
+}
 \description{
 covariate function builder
 }

--- a/man/get_ode_model_size.Rd
+++ b/man/get_ode_model_size.Rd
@@ -10,6 +10,9 @@ get_ode_model_size(code)
 \arguments{
 \item{code}{C++ code}
 }
+\value{
+Number of states in the ODE model
+}
 \description{
 Get the number of states in the ODE from the code
 code C++ code for model

--- a/man/get_parameters_from_code.Rd
+++ b/man/get_parameters_from_code.Rd
@@ -13,6 +13,9 @@ get_parameters_from_code(code, state_init, declare_variables = NULL)
 
 \item{declare_variables}{declared variables}
 }
+\value{
+Vector of parameter names
+}
 \description{
 Get model parameters from code
 }

--- a/man/get_var_y.Rd
+++ b/man/get_var_y.Rd
@@ -73,7 +73,7 @@ get_var_y(
 \item{...}{passed on to `sim_ode()`}
 }
 \value{
-Standard deviation or variance (or quantiles thereof) for dependent
+Vector of standard deviations or variances (or quantiles thereof) for dependent value
   variable
 }
 \description{

--- a/man/get_var_y.Rd
+++ b/man/get_var_y.Rd
@@ -72,6 +72,10 @@ get_var_y(
 
 \item{...}{passed on to `sim_ode()`}
 }
+\value{
+Standard deviation or variance (or quantiles thereof) for dependent
+  variable
+}
 \description{
 Get expected variance/sd/ci of dependent variable
 based on PKPDsim model, parameters, and regimen

--- a/man/ifelse0.Rd
+++ b/man/ifelse0.Rd
@@ -13,6 +13,9 @@ ifelse0(value = NULL, alternative = NULL, allow_null = FALSE)
 
 \item{allow_null}{can the alternative be NULL?}
 }
+\value{
+\code{value} if non-NULL; \code{alternative} otherwise
+}
 \description{
 ifelse function but then based on whether value is NULL or not
 }

--- a/man/is_positive_definite.Rd
+++ b/man/is_positive_definite.Rd
@@ -7,7 +7,10 @@
 is_positive_definite(x)
 }
 \arguments{
-\item{x}{matrix, specified either as `vector` of lower triangle, or full matrix (as `matrix` class)}
+\item{x}{matrix, specified either as \code{vector} of lower triangle, or full matrix (as \code{matrix} class)}
+}
+\value{
+TRUE if \code{x} is positive definite; FALSE otherwise.
 }
 \description{
 Is matrix positive definite

--- a/man/join_cov_and_par.Rd
+++ b/man/join_cov_and_par.Rd
@@ -11,6 +11,9 @@ join_cov_and_par(covs, pars)
 
 \item{pars}{model parameters, such as the output of the `parameters()` call frmo a model library.}
 }
+\value{
+List containing covariates and parameters
+}
 \description{
 Combines covariates and parameters into a single list, useful for reparametrization of the model.
 }

--- a/man/join_regimen.Rd
+++ b/man/join_regimen.Rd
@@ -26,6 +26,9 @@ join_regimen(
 
 \item{continuous}{for joining continuous infusions}
 }
+\value{
+Joined regimen
+}
 \description{
 Join two dosing regimens
 }

--- a/man/merge_regimen.Rd
+++ b/man/merge_regimen.Rd
@@ -9,6 +9,9 @@ merge_regimen(regimens)
 \arguments{
 \item{regimens}{List of PKPDsim regimens created with `new_regimen`.}
 }
+\value{
+Merged regimens
+}
 \description{
 In contrast to `join_regimen`, which joins two consecutive regimens together, `merge_regimen` merges two or
 more regimens given at the same time. This can e.g. be used to define regimens for multi-drug models.

--- a/man/model_from_api.Rd
+++ b/man/model_from_api.Rd
@@ -33,7 +33,10 @@ model_from_api(
 
 \item{install_all}{force install all, even if model inactive}
 
-\item{...}{arguments passed to `new_ode_model()` function}
+\item{...}{arguments passed to \code{new_ode_model()} function}
+}
+\value{
+Model object created with \code{\link[=new_ode_model]{new_ode_model()}}
 }
 \description{
 Load model definition from API, and compile to R library

--- a/man/model_library.Rd
+++ b/man/model_library.Rd
@@ -9,6 +9,9 @@ model_library(name = NULL)
 \arguments{
 \item{name}{name of model in library. If none specified, will show list of available models.}
 }
+\value{
+List containing information about the named model
+}
 \description{
 Model library
 }

--- a/man/mvrnorm2.Rd
+++ b/man/mvrnorm2.Rd
@@ -19,8 +19,11 @@ mvrnorm2(n, mu, Sigma, exponential = FALSE, sequence = NULL, ...)
 
 \item{...}{parameters passed to mvrnorm or randtoolbox sequence generator}
 }
+\value{
+Multivariate normal samples
+}
 \description{
-Besides standard mutlivariate normal sampling (mvrnorm), allows exponential
+Besides standard multivariate normal sampling (mvrnorm), allows exponential
 multivarate normal and quasi-random multivariate normal (using the randtoolbox)
 all using the same interface.
 }

--- a/man/na_locf.Rd
+++ b/man/na_locf.Rd
@@ -13,7 +13,7 @@ na_locf(object, fromLast = FALSE)
 than forward. Default is FALSE.}
 }
 \value{
-Original object iwth NAs filled in
+Original object with NAs filled in
 }
 \description{
 Inspired by zoo::na.locf0

--- a/man/na_locf.Rd
+++ b/man/na_locf.Rd
@@ -9,7 +9,11 @@ na_locf(object, fromLast = FALSE)
 \arguments{
 \item{object}{an object}
 
-\item{fromLast}{logical. Causes observations to be carried backward rather than forward. Default is FALSE. With a value of TRUE this corresponds to NOCB (next observation carried backward). It is not supported if x or xout is specified.}
+\item{fromLast}{logical. Causes observations to be carried backward rather
+than forward. Default is FALSE.}
+}
+\value{
+Original object iwth NAs filled in
 }
 \description{
 Inspired by zoo::na.locf0

--- a/man/new_adherence.Rd
+++ b/man/new_adherence.Rd
@@ -27,6 +27,8 @@ to adherent state}
 \value{
 Returns a vector of length `n`
   containing values 0 (non-adherent) or 1 (adherent).
+
+Numeric vector of length n
 }
 \description{
 Model the drug adherence using either a binomial probability distribution or

--- a/man/new_covariate.Rd
+++ b/man/new_covariate.Rd
@@ -33,7 +33,7 @@ new_covariate(
 \item{verbose}{verbosity}
 }
 \value{
-Object of class `"covariate"
+Object of class \code{"covariate"}
 }
 \description{
 Describe data for a covariate, either fixed or time-variant

--- a/man/new_covariate.Rd
+++ b/man/new_covariate.Rd
@@ -24,13 +24,16 @@ new_covariate(
 
 \item{unit}{specify covariate unit (optional, for documentation purposes only)}
 
-\item{interpolation_join_limit}{for `interpolate` option, if covariate timepoints are spaced too close together, the ODE solver sometimes chokes. This argument sets a lower limit on the space between timepoints. It will create average values on joint timepoints instead. If undesired set to NULL or 0.}
+\item{interpolation_join_limit}{for \code{interpolate} option, if covariate timepoints are spaced too close together, the ODE solver sometimes chokes. This argument sets a lower limit on the space between timepoints. It will create average values on joint timepoints instead. If undesired set to NULL or 0.}
 
-\item{remove_negative_times}{`TRUE`` or `FALSE`}
+\item{remove_negative_times}{\verb{TRUE`` or }FALSE`}
 
-\item{comments}{`NULL`, or vector of length equal to `value` specifying comments to each observation}
+\item{comments}{\code{NULL}, or vector of length equal to \code{value} specifying comments to each observation}
 
 \item{verbose}{verbosity}
+}
+\value{
+Object of class `"covariate"
 }
 \description{
 Describe data for a covariate, either fixed or time-variant

--- a/man/new_covariate_model.Rd
+++ b/man/new_covariate_model.Rd
@@ -9,6 +9,9 @@ new_covariate_model(model = list())
 \arguments{
 \item{model}{covariate model specified as list}
 }
+\value{
+List containing model function(s)
+}
 \description{
 covariate model function
 }

--- a/man/new_ode_model.Rd
+++ b/man/new_ode_model.Rd
@@ -127,6 +127,10 @@ new_ode_model(
 output cmd line output. Default (`""`) is R console, NULL or FALSE discards.
 TRUE captures the output and saves as a file.}
 }
+\value{
+If package name is NULL, returns the model object. Otherwise has no
+  return value.
+}
 \description{
 Create new ODE model
 }

--- a/man/nlmixr_parse_parameters.Rd
+++ b/man/nlmixr_parse_parameters.Rd
@@ -26,6 +26,9 @@ nlmixr_parse_parameters(
 
 \item{...}{passed on}
 }
+\value{
+List of parameters that can be used by nlmixr
+}
 \description{
 Function to parse parameters for a model into a structure used by nlmixr
 }

--- a/man/nm_to_regimen.Rd
+++ b/man/nm_to_regimen.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/nm_to_regimen.R
 \name{nm_to_regimen}
 \alias{nm_to_regimen}
-\title{Create a regimen from NM data}
+\title{Create a regimen from NONMEM data}
 \usage{
 nm_to_regimen(data, reset_time = TRUE, first_only = FALSE)
 }
@@ -12,6 +12,9 @@ nm_to_regimen(data, reset_time = TRUE, first_only = FALSE)
 \item{reset_time}{start time for each simulated patient at 0, irrespective of design in dataset}
 
 \item{first_only}{use only design from first individual in dataset}
+}
+\value{
+Regimen object
 }
 \description{
 Create a regimen based on a NONMEM, or NONMEM-like dataset

--- a/man/pkpdsim_to_nlmixr.Rd
+++ b/man/pkpdsim_to_nlmixr.Rd
@@ -38,6 +38,9 @@ pkpdsim_to_nlmixr(
 
 \item{...}{passed on}
 }
+\value{
+nlmixr function
+}
 \description{
 Convert a model generated with PKPDsim to an object for nlmixr
 }

--- a/man/pop_regimen.Rd
+++ b/man/pop_regimen.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/pop_regimen.R
 \name{pop_regimen}
 \alias{pop_regimen}
-\title{Remove n doses (from tail) of PKPDsim regimen
-Opposite of shift_regimen()}
+\title{Remove n doses (from tail) of PKPDsim regimen}
 \usage{
 pop_regimen(regimen, n = 1)
 }
@@ -12,7 +11,12 @@ pop_regimen(regimen, n = 1)
 
 \item{n}{number of doses to pop from regimen}
 }
+\value{
+Input regiment minus selected number of doses
+}
 \description{
-Remove n doses (from tail) of PKPDsim regimen
 Opposite of shift_regimen()
+}
+\seealso{
+shift_regimen
 }

--- a/man/print_list.Rd
+++ b/man/print_list.Rd
@@ -13,6 +13,9 @@ print_list(x, wrapper = TRUE, quote = FALSE)
 
 \item{quote}{add quotes to values in list definition?}
 }
+\value{
+Original list in R syntax
+}
 \description{
 Return a list in R syntax
 }

--- a/man/read_model_json.Rd
+++ b/man/read_model_json.Rd
@@ -9,6 +9,9 @@ read_model_json(path)
 \arguments{
 \item{path}{Path to JSON file}
 }
+\value{
+List containing contents of original JSON file
+}
 \description{
 Does some substitution of escaped characters in strings in the JSON file,
 then converts to a list with \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}

--- a/man/regimen_to_nm.Rd
+++ b/man/regimen_to_nm.Rd
@@ -17,6 +17,9 @@ regimen_to_nm(reg = NULL, dose_cmt = 1, n_ind = 1, t_obs = NULL, obs_cmt = 1)
 
 \item{obs_cmt}{observation compartment for added observation time(s)}
 }
+\value{
+Data frame containing doses
+}
 \description{
 Convert PKPDsim regimen to NONMEM table (doses only)
 }

--- a/man/reparametrize.Rd
+++ b/man/reparametrize.Rd
@@ -13,6 +13,9 @@ reparametrize(model, parameters, covariates)
 
 \item{covariates}{covariates list, specified as PKPDsim covariates}
 }
+\value{
+Reparameterized model parameters
+}
 \description{
 Mostly useful for reparametrizing models into standard parametrizations, e.g. to
 NONMEM TRANS or clinPK parametrizations.

--- a/man/search_replace_in_file.Rd
+++ b/man/search_replace_in_file.Rd
@@ -13,6 +13,9 @@ search_replace_in_file(files = c(), find = NULL, replacement = NULL)
 
 \item{replacement}{replace with what, vector of character, should be equal in lenght to `find`}
 }
+\value{
+Function does not return a value but edits files on disk
+}
 \description{
 Find string and replace in file
 }

--- a/man/shift_regimen.Rd
+++ b/man/shift_regimen.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/shift_regimen.R
 \name{shift_regimen}
 \alias{shift_regimen}
-\title{Remove n doses (from start) of PKPDsim regimen
-Opposite of pop_regimen()}
+\title{Remove n doses (from start) of PKPDsim regimen}
 \usage{
 shift_regimen(regimen, n = 1, reset_time = TRUE)
 }
@@ -14,7 +13,12 @@ shift_regimen(regimen, n = 1, reset_time = TRUE)
 
 \item{reset_time}{reset the remaining doses to start at t=0?}
 }
+\value{
+Regimen with selected number of doses removed from start
+}
 \description{
-Remove n doses (from start) of PKPDsim regimen
 Opposite of pop_regimen()
+}
+\seealso{
+pop_regimen
 }

--- a/man/sim.Rd
+++ b/man/sim.Rd
@@ -127,43 +127,53 @@ Simulates a specified regimen using ODE system or analytical equation
 }
 \examples{
 \dontrun{
-library(ggplot2)
-library(PKPDsim)
-p <- list(CL = 38.48,
-         V  = 7.4,
-         Q  = 7.844,
-         V2 = 5.19,
-         Q2  = 9.324,
-         V3 = 111)
+p <- list(
+  CL = 38.48,
+  V  = 7.4,
+  Q  = 7.844,
+  V2 = 5.19,
+  Q2  = 9.324,
+  V3 = 111
+)
 
-r1 <- new_regimen(amt = 100,
-             times = c(0, 24, 36),
-             type = "infusion")
+r1 <- new_regimen(
+  amt = 100,
+  times = c(0, 24, 36),
+  type = "infusion"
+)
 
 mod <- new_ode_model("pk_3cmt_iv")
-dat <- sim(ode = mod,
-          parameters = p,
-          regimen = r1)
+dat <- sim(
+  ode = mod,
+  parameters = p,
+  regimen = r1
+)
 
-ggplot(dat, aes(x=t, y=y)) +
- geom_line() +
- scale_y_log10() +
- facet_wrap(~comp)
+dat_wide <- reshape(
+  dat,
+  direction = "wide",
+  timevar = "comp",
+  idvar = "t"
+)
+
+matplot(
+  dat_wide[, grepl("^y", names(dat_wide))],
+  type = "b",
+  pch = 1,
+  log = "y"
+)
 
 # repeat with IIV:
 omega <- c(0.3,       # IIV CL
-          0.1, 0.3)  # IIV V
+           0.1, 0.3)  # IIV V
 
-dat <- sim (ode = mod,
-           parameters = p,
-           omega = omega,
-           n_ind = 20,
-           regimen = r1)
-
-ggplot(dat, aes(x=t, y=y, colour=factor(id), group=id)) +
- geom_line() +
- scale_y_log10() +
- facet_wrap(~comp)
+dat <- sim(
+  ode = mod,
+  parameters = p,
+  omega = omega,
+  n_ind = 20,
+  regimen = r1
+)
 }
 }
 \seealso{

--- a/man/sim.Rd
+++ b/man/sim.Rd
@@ -121,6 +121,8 @@ sim(
 }
 \value{
 a data frame of compartments with associated concentrations at requested times
+
+Simulated regimen
 }
 \description{
 Simulates a specified regimen using ODE system or analytical equation

--- a/man/sim_core.Rd
+++ b/man/sim_core.Rd
@@ -17,7 +17,7 @@ sim_core(sim_object = NULL, ode, duplicate_t_obs = FALSE, t_init = 0)
 \item{t_init}{time of initization of the ODE system. Usually 0.}
 }
 \value{
-Data frame of observations
+Data frame with simulation results
 }
 \description{
 Only core function of the simulation function, always just returns observations.

--- a/man/sim_core.Rd
+++ b/man/sim_core.Rd
@@ -16,6 +16,9 @@ sim_core(sim_object = NULL, ode, duplicate_t_obs = FALSE, t_init = 0)
 
 \item{t_init}{time of initization of the ODE system. Usually 0.}
 }
+\value{
+Data frame of observations
+}
 \description{
 Only core function of the simulation function, always just returns observations.
 Mostly useful for estimations / optimal design. Has no checks (for speed)!

--- a/man/sim_ode.Rd
+++ b/man/sim_ode.Rd
@@ -2,13 +2,19 @@
 % Please edit documentation in R/sim_ode.R
 \name{sim_ode}
 \alias{sim_ode}
-\title{Deprecated function, renamed to `sim()`}
+\title{Deprecated function, renamed to \code{sim()}}
 \usage{
 sim_ode(...)
 }
 \arguments{
-\item{...}{parameters passed to `sim()` function}
+\item{...}{parameters passed to \code{sim()} function}
+}
+\value{
+Output from \code{\link[=sim]{sim()}}
 }
 \description{
-Deprecated function, renamed to `sim()`
+Deprecated function, renamed to \code{sim()}
+}
+\seealso{
+sim
 }

--- a/man/sim_ode_shiny.Rd
+++ b/man/sim_ode_shiny.Rd
@@ -9,8 +9,12 @@ sim_ode_shiny(...)
 \arguments{
 \item{...}{arguments passed to PKPDsimShiny::sim_ode_shiny()}
 }
+\value{
+No return value
+}
 \description{
-Simulate ODE and create a Shiny app
+This function has been deprecated and moved to a separate package at
+https://github.com/ronkeizer/PKPDsimshiny.
 }
 \seealso{
 \link{sim_ode}

--- a/man/table_to_list.Rd
+++ b/man/table_to_list.Rd
@@ -9,6 +9,9 @@ table_to_list(table)
 \arguments{
 \item{table}{data.frame}
 }
+\value{
+List containing original table contents
+}
 \description{
 Convert a table to a list
 }

--- a/man/test_model.Rd
+++ b/man/test_model.Rd
@@ -16,6 +16,9 @@ test_model(url, test_file, package, force = FALSE)
 \item{force}{Run tests even if model is not flagged for building? Defaults to
 FALSE}
 }
+\value{
+Runs test file for a model but does not return a value
+}
 \description{
 Test a model
 }

--- a/man/test_pointer.Rd
+++ b/man/test_pointer.Rd
@@ -9,6 +9,9 @@ test_pointer(model)
 \arguments{
 \item{model}{pointer to model}
 }
+\value{
+No return value
+}
 \description{
 Test if model still in memory
 }

--- a/man/translate_ode.Rd
+++ b/man/translate_ode.Rd
@@ -17,6 +17,9 @@ translate_ode(code, auto = TRUE, from = NULL, to = NULL, verbose = TRUE)
 
 \item{verbose}{verbose, `TRUE` or `FALSE`}
 }
+\value{
+Translated PKPDsim or RxODE model
+}
 \description{
 Currently only supports PKDPsim <--> RxODE
 }

--- a/man/triangle_to_full.Rd
+++ b/man/triangle_to_full.Rd
@@ -9,6 +9,9 @@ triangle_to_full(vect)
 \arguments{
 \item{vect}{vector specifying triangle omega matrix}
 }
+\value{
+Omega matrix
+}
 \description{
 Convert triangle omega matrix to full omega matrix
 }

--- a/tests/testthat/test_model_from_api.R
+++ b/tests/testthat/test_model_from_api.R
@@ -10,6 +10,7 @@ test_that("Can specify a package from json", {
 })
 
 test_that("Can install a package from json", {
+  skip_on_cran()
   # This test specifies tmp directories explicitly during install.
   # Environment settings for tmp directories change from system to system
   # and so this approach ensures consistency.


### PR DESCRIPTION
Updates the repo based on some of the things listed in [extrachecks](https://github.com/DavisVaughan/extrachecks). The main thing was adding `@return` documentation for every exported function. I also tried to update the package title and description to be a little more informative, and changed the `sim()` example so that it does not use ggplot2 (since we don't list ggplot2 as a suggested dependency in the DESCRIPTION).

I did not add return value documentation for `analytical_eqn_wrapper()` or `sim_core_analytic()` until we decide if we're keeping those per RXR-633.