### PR TITLE
slight re-order of C++ code in main loop to make sure IOV on bioavailability is correctly applied

### DIFF
--- a/inst/cpp/sim.cpp
+++ b/inst/cpp/sim.cpp
@@ -96,21 +96,22 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
 
     set_covariates(i);
 
+    if(evid[i] == 1) {
+      t_prv_dose = times[i];
+      prv_dose = doses[i];
+    }
+    pk_code(i, times, doses, prv_dose, dose_cmt, dose_type, iov_bin);
     // insert bioav definition
     if(dummy[i] == 1 || (doses[i] > 0 && dose_type[i] == 1)) { // change rate if start of dose, or if end of infusion
       rate[dose_cmt[i]-1] = (rate[dose_cmt[i]-1])*1.0 + rates[i] * bioav[dose_cmt[i]-1];
     }
     // insert scale definition for integration period
-        
-    pk_code(i, times, doses, prv_dose, dose_cmt, dose_type, iov_bin);
 
     start = 0;
     if(i > 0) {
       start = 1;
     }
     if(evid[i] == 1) {
-      t_prv_dose = times[i];
-      prv_dose = doses[i];
       if(dose_type[i] == 0) { // bolus
         Aupd[dose_cmt[i]-1] = Aupd[dose_cmt[i]-1] + doses[i] * bioav[dose_cmt[i]-1];
         start = 0;

--- a/tests/testthat/test_iov.R
+++ b/tests/testthat/test_iov.R
@@ -71,3 +71,62 @@ test_that("IOV is added to parameters", {
   )
 })
 
+test_that("Change in F in 2nd bin is applied in 2nd bin and not later.", {
+  # Previously this was an issue because F, when defined in pk_code(), was not updated before the
+  # dose was applied to the state vector, so the bioavailability was not applied at the right time.
+  # This was fixed by rearranging the order of execution in sim.cpp in the main loop.
+
+  pars <- list(
+    "CL" = 5,
+    "V" = 50,
+    "KA" = 1,
+    "F" = 1
+  )
+  pk1 <- new_ode_model(
+    code = "
+        dAdt[1] = -KA * A[1]
+        dAdt[2] = +KA * A[1] -(CLi/V) * A[2]
+    ",
+    pk_code = "
+        Fi = F * exp(kappa_F);
+        CLi = CL;
+    ",
+    iov = list(
+      cv = list(F = 0.2),
+      n_bins = 4
+    ),
+    obs = list(cmt = 2, scale = "V"),
+    dose = list(cmt = 1, bioav = "Fi"),
+    declare_variables = c("kappa_F", "Fi", "CLi"),
+    parameters = names(pars),
+    cpp_show_code = F
+  )
+  reg <- new_regimen(amt = 800, interval = 24, n = 10, type = "oral")
+
+  # For a first simulation, we're simulating with no variability across the IOV bins:
+  pars$kappa_F_1 <- 0
+  pars$kappa_F_2 <- 0
+  pars$kappa_F_3 <- 0
+  args_sim1 <- args <- list(
+    ode = pk1,
+    parameters = pars,
+    regimen = reg,
+    only_obs = TRUE,
+    t_obs = seq(0, 50, .25),
+    iov_bins = c(0L, 24L, 48L, 9999L)
+  )
+  # For a second simulation, we're applying a change in parameter for the 2nd bin (24-48 hrs).
+  # This should affect predictions from 24 onward.
+  pars$kappa_F_2 <- 1 # 2nd bin
+  args_sim2 <- args <- list(
+    ode = pk1,
+    parameters = pars,
+    regimen = reg,
+    only_obs = TRUE,
+    t_obs = seq(0, 50, .25),
+    iov_bins = c(0L, 24L, 48L, 9999L)
+  )
+  res1 <- do.call("sim_ode", args = args_sim1)
+  res2 <- do.call("sim_ode", args = args_sim2)
+  expect_true(min(res1[res1$y != res2$y,]$t) <= 25)
+})


### PR DESCRIPTION
Because of the order of code in the sim.cpp, IOV defined in the PK block wasn’t called at the right times to actually affect biovailability properly. Requires a small change of order of code execution in the main loop in sim.cpp. 

Check that it doesn’t affect other models: in progress
Add a unit test: haven't been able yet to create a unit test that catches the error.