### PR TITLE
RXR-837 fix order output for models with lagtime

### DIFF
--- a/R/sim.R
+++ b/R/sim.R
@@ -573,7 +573,7 @@ sim <- function (ode = NULL,
   comb$t_obs_type <- paste(comb$t, comb$obs_type, sep = "_")
   comb$rownr <- 1:nrow(comb) # keep row-ordering during merge
   comb <- merge(grid, comb, all=FALSE)[, c("id", "t_obs_type", "t", "comp", "y", "obs_type", "rownr", all_names)]
-  comb <- comb[order(comb$id, comb$comp, comb$t, comb$obs_type, comb$rownr, decreasing=FALSE), -2]
+  comb <- comb[order(comb$id, comb$comp, comb$t, comb$obs_type, comb$rownr, decreasing=FALSE), -c(2, 7)]
   if(!is.null(regimen_orig$ss_regimen)) {
     t_ss <- utils::tail(regimen_orig$ss_regimen$dose_times,1) + regimen_orig$ss_regimen$interval
     comb$t <- as.num(comb$t) - t_ss
@@ -588,7 +588,6 @@ sim <- function (ode = NULL,
       obs_type = comb[comb$comp == 'obs',]$obs_type)
   }
   comb$t <- comb$t - t_init
-  comb$rownr <- NULL
 
   class(comb) <- c("PKPDsim_data", class(comb))
   attr(comb, "regimen") <- regimen_orig

--- a/R/sim.R
+++ b/R/sim.R
@@ -573,7 +573,8 @@ sim <- function (ode = NULL,
   comb$t_obs_type <- paste(comb$t, comb$obs_type, sep = "_")
   comb$rownr <- 1:nrow(comb) # keep row-ordering during merge
   comb <- merge(grid, comb, all=FALSE)[, c("id", "t_obs_type", "t", "comp", "y", "obs_type", "rownr", all_names)]
-  comb <- comb[order(comb$id, comb$comp, comb$t, comb$obs_type, comb$rownr, decreasing=FALSE), -c(2, 7)]
+  rm_cols <- which(colnames(comb) %in% c("t_obs_type", "rownr"))
+  comb <- comb[order(comb$id, comb$comp, comb$t, comb$obs_type, comb$rownr, decreasing=FALSE), -rm_cols]
   if(!is.null(regimen_orig$ss_regimen)) {
     t_ss <- utils::tail(regimen_orig$ss_regimen$dose_times,1) + regimen_orig$ss_regimen$interval
     comb$t <- as.num(comb$t) - t_ss

--- a/R/sim.R
+++ b/R/sim.R
@@ -571,8 +571,9 @@ sim <- function (ode = NULL,
   grid <- expand.grid(paste(t_obs, obs_type, sep="_"), unique(comb$id), unique(comb$comp))
   colnames(grid) <- c("t_obs_type", "id", "comp")
   comb$t_obs_type <- paste(comb$t, comb$obs_type, sep = "_")
-  comb <- merge(grid, comb, all=FALSE)[, c("id", "t_obs_type", "t", "comp", "y", "obs_type", all_names)]
-  comb <- comb[order(comb$id, comb$comp, comb$t, comb$obs_type, decreasing=FALSE), -2]
+  comb$rownr <- 1:nrow(comb) # keep row-ordering during merge
+  comb <- merge(grid, comb, all=FALSE)[, c("id", "t_obs_type", "t", "comp", "y", "obs_type", "rownr", all_names)]
+  comb <- comb[order(comb$id, comb$comp, comb$t, comb$obs_type, comb$rownr, decreasing=FALSE), -2]
   if(!is.null(regimen_orig$ss_regimen)) {
     t_ss <- utils::tail(regimen_orig$ss_regimen$dose_times,1) + regimen_orig$ss_regimen$interval
     comb$t <- as.num(comb$t) - t_ss
@@ -587,6 +588,7 @@ sim <- function (ode = NULL,
       obs_type = comb[comb$comp == 'obs',]$obs_type)
   }
   comb$t <- comb$t - t_init
+  comb$rownr <- NULL
 
   class(comb) <- c("PKPDsim_data", class(comb))
   attr(comb, "regimen") <- regimen_orig

--- a/tests/testthat/test_sim_lagtime.R
+++ b/tests/testthat/test_sim_lagtime.R
@@ -1,4 +1,5 @@
 test_that("dose dump after lagtime in correct order in output data", {
+  skip_on_cran()
   reg <- new_regimen(amt = 500, n = 4, interval = 12, type = 'oral')
   pars <- list(CL = 5, V = 50, KA = 0.5, TLAG = 0.83)
   mod <- new_ode_model(

--- a/tests/testthat/test_sim_lagtime.R
+++ b/tests/testthat/test_sim_lagtime.R
@@ -1,0 +1,21 @@
+test_that("dose dump after lagtime in correct order in output data", {
+  reg <- new_regimen(amt = 500, n = 4, interval = 12, type = 'oral')
+  pars <- list(CL = 5, V = 50, KA = 0.5, TLAG = 0.83)
+  mod <- new_ode_model(
+    code = "
+      dAdt[0] = -KA * A[0]
+      dAdt[1] = +KA * A[0] -(CL/V) * A[1]
+  ",
+    lagtime = c("TLAG", 0),
+    obs = list(cmt = 2, scale = "V"),
+    dose = list(cmt = 1, bioav = 1),
+    parameters = pars
+  )
+  dat <- sim_ode(
+    ode = mod,
+    regimen = reg,
+    parameters = pars,
+    only_obs = FALSE
+  )
+  expect_equal(round(dat[dat$t == 12.83 & dat$comp == 1,]$y, 1), c(1.2, 501.2))
+})


### PR DESCRIPTION
For some models with lagtimes for oral drugs, the amounts in compartment 1 will show a spike, due to the erroneous re-ordering of the output after simulation. The cause is a merge() command that altered the order of the output from the simulater. No “wrong” concentrations were simulated for any model, it’s just the output that was in some cases not arranged correctly.