### PR TITLE
RXR-982: Run check in correct directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         sh """
         docker cp . ${BUILD_TAG}:/src/PKPDsim
         docker exec -i ${BUILD_TAG} Rscript -e "install.packages('mockery')"
-        docker exec -i ${BUILD_TAG} Rscript -e "Sys.setlocale('LC_ALL','C'); devtools::check('PKPDsim')"
+        docker exec -i ${BUILD_TAG} Rscript -e "Sys.setlocale('LC_ALL','C'); devtools::check('/src/PKPDsim')"
         """
       }
     }


### PR DESCRIPTION
The PKPDsim source code is in `/src` but the latest irx-r-base image changes the working directory to something else, so I've updated the jenkinsfile here to run `devtools::check()` with the absolute path.