### PR TITLE
RXR-1070: fix directory of built packages

### DIFF
--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -427,11 +427,9 @@ new_ode_model <- function (model = NULL,
         # Run R CMD BUILD to zip file
         args <- c("CMD", "build", normalizePath(file.path(folder, package)))
         system2(cmd, args, stdout = quiet, stderr = quiet)
-        pkg_file <- paste0(new_folder, .Platform$file.sep, package, "_", version, ".tar.gz")
-        pkg_newfile <- paste0(getwd(), .Platform$file.sep, package, "_", version, ".tar.gz")
+        pkg_file <- paste0(package, "_", version, ".tar.gz")
         if(file.exists(pkg_file)) {
-          file.copy(pkg_file, pkg_newfile)
-          message(paste0("Package built in: ", pkg_newfile))
+          message(paste0("Package built in: ", file.path(getwd(), pkg_file)))
         } else {
           message("Package not created.")
         }

--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -393,7 +393,7 @@ new_ode_model <- function (model = NULL,
 
       ## Compile / build / install
       if(file.exists(file.path(new_folder, "R", "RcppExports.R"))) {
-        file.remove(paste0(new_folder, "R", "RcppExports.R"))
+        file.remove(file.path(new_folder, "R", "RcppExports.R"))
       }
       if(file.exists(file.path(new_folder, "src", "RcppExports.cpp"))) {
         file.remove(file.path(new_folder, "src", "RcppExports.cpp"))


### PR DESCRIPTION
I was seeing a lot of "Package not created" messages when building our models. On investigation, this was due to a change in #28 where we we stopped changing the working directory, but didn't update the rest of the logic for where to find the built tarball. I've fixed it, plus another issue that was throwing a warning.