### PR TITLE
RXR-1050: Fix github actions

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,13 +19,13 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown
           needs: website
 
       - name: Deploy package


### PR DESCRIPTION
pkgdown started failing after #46, I updated to the latest version of the `setup-r` and `setup-r-dependencies` actions and that seems to have resolved it.