### PR TITLE
RXR-1228 fix bug when joining regimens with no t_inf

### DIFF
--- a/R/join_regimen.R
+++ b/R/join_regimen.R
@@ -36,7 +36,7 @@ join_regimen <- function(
     regimen1$dose_amts <- c(regimen1$dose_amts[keep], regimen2$dose_amts)
     ## when we join, we don't want the last infusion to overlap with
     ## the 1st one from the 2nd regimen, and should run until then.
-    if(length(keep) > 0 && regimen1$t_inf[max(keep)] > (t_dose_update - regimen1$dose_times[max(keep)])) {
+    if(isTRUE(length(keep) > 0 && regimen1$t_inf[max(keep)] > (t_dose_update - regimen1$dose_times[max(keep)]))) {
       planned_t_inf <- regimen1$t_inf[max(keep)]
       new_t_inf <- t_dose_update - max(regimen1$dose_times[keep])
       regimen1$t_inf[max(keep)] <- new_t_inf
@@ -81,7 +81,7 @@ join_regimen <- function(
     }
     ## when we join, we don't want the last infusion to overlap with
     ## the 1st one from the 2nd regimen, and should run until then.
-    if(tail(regimen1$t_inf,1) > interval) {
+    if(isTRUE(tail(regimen1$t_inf,1) > interval)) {
       planned_t_inf <- tail(regimen1$t_inf,1)
       regimen1$t_inf[length(regimen1$t_inf)] <- interval
       regimen1$dose_amts[length(regimen1$t_inf)] <- regimen1$dose_amts[length(regimen1$t_inf)] * interval / planned_t_inf

--- a/tests/testthat/test_join_regimen.R
+++ b/tests/testthat/test_join_regimen.R
@@ -66,3 +66,11 @@ test_that("one null regimen returns the other", {
   expect_equal(join_regimen(reg1, NULL), reg1)
 })
 
+test_that("join regimen works when no t_inf specified, e.g. oral or sc dosing", {
+  reg_i <- new_regimen(amt = 500, type = "sc", times = c(0, 2, 6)*24*7)
+  reg_m <- new_regimen(amt = 400, type = "sc", n = 5, interval = 8*7*24)
+  reg <- join_regimen(reg_i, reg_m, interval = 8*7*24)
+  expect_equal(reg$dose_times, c(0, 336, 1008, 2352, 3696, 5040, 6384, 7728))
+  expect_equal(reg$type, c("sc", "sc", "sc", "sc", "sc", "sc", "sc", "sc"))
+  expect_equal(reg$dose_amts, c(500, 500, 500, 400, 400, 400, 400, 400))
+})


### PR DESCRIPTION
When a drug is oral or SC administered, it will not have a t_inf specified. This PR fixes the behavior and adds a test.