### PR TITLE
RXR-1298: allow empty lists in print_list()

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -80,7 +80,7 @@ add_quotes <- function(x, quote = "double") {
 #' @export
 #' @return Original list in R syntax
 print_list <- function(x, wrapper = TRUE, quote = FALSE) {
-  if(is.null(x)) return("")
+  if(is.null(x) || length(x) == 0) return("")
   if(!quote) {
     tmp <- paste(PKPDsim::add_quotes(names(x)), "=", x[names(x)], collapse = ", ")
   } else {

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -7,3 +7,9 @@ test_that("now_utc returns time in UTC", {
   now <- now_utc()
   expect_equal(attr(now, "tzone"), "UTC")
 })
+
+test_that("print_list supports empty lists", {
+  x <- list()
+  res <- print_list(x)
+  expect_equal(res, "")
+})


### PR DESCRIPTION
This will allow us to list development info as `"development": {}` in the model json in cases where the development population isn't known.