### PR TITLE
Rewrite print_list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PKPDsim
 Type: Package
 Title: Tools for Performing Pharmacokinetic-Pharmacodynamic Simulations
-Version: 1.2.1
+Version: 1.2.9999
 Date: 2022-10-13
 Authors@R: c(
         person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PKPDsim
 Type: Package
 Title: Tools for Performing Pharmacokinetic-Pharmacodynamic Simulations
-Version: 1.2.9999
+Version: 1.2.1
 Date: 2022-10-13
 Authors@R: c(
         person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("aut", "cre")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,8 @@
 S3method(print,PKPDsim)
 S3method(print,covariate)
 S3method(print,regimen)
+S3method(print_list,"NULL")
+S3method(print_list,list)
 export(add_quotes)
 export(add_ruv)
 export(add_ruv_to_quantile)

--- a/R/misc.R
+++ b/R/misc.R
@@ -76,20 +76,27 @@ add_quotes <- function(x, quote = "double") {
 #'
 #' @param x list to be printed
 #' @param wrapper wrap in list object?
-#' @param quote add quotes to values in list definition?
 #' @export
 #' @return Original list in R syntax
-print_list <- function(x, wrapper = TRUE, quote = FALSE) {
-  if(is.null(x) || length(x) == 0) return("")
-  if(!quote) {
-    tmp <- paste(PKPDsim::add_quotes(names(x)), "=", x[names(x)], collapse = ", ")
+print_list <- function(x, wrapper = TRUE) {
+  UseMethod("print_list")
+}
+
+#' @export
+print_list.NULL <- function(x, wrapper = TRUE) {
+  return("")
+}
+
+#' @export
+print_list.list <- function(x, wrapper = TRUE) {
+  if(length(x) == 0) return("")
+  result <- paste0(capture.output(dput(x)), collapse = "")
+  if(isTRUE(wrapper)) {
+    return(result)
   } else {
-    tmp <- paste(PKPDsim::add_quotes(names(x)), "=", add_quotes(x[names(x)]), collapse = ", ")
-  }
-  if(wrapper) {
-    return(paste0("list (", tmp, ")"))
-  } else {
-    return(tmp)
+    result <- gsub("^list\\(", "", result)
+    result <- gsub("\\)$", "", result)
+    result
   }
 }
 

--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -367,7 +367,7 @@ new_ode_model <- function (model = NULL,
         default_parameters <- PKPDsim::print_list(default_parameters, FALSE)
       }
       if(is.null(units)) { units <- "''" } else {
-        units <- PKPDsim::print_list(units, TRUE, TRUE)
+        units <- PKPDsim::print_list(units, wrapper = TRUE)
       }
       search_replace_in_file(file.path(new_folder, "R", "iiv.R"), "\\[IIV\\]", iiv)
       search_replace_in_file(file.path(new_folder, "R", "iov.R"), "\\[IOV\\]", iov)

--- a/man/print_list.Rd
+++ b/man/print_list.Rd
@@ -4,14 +4,12 @@
 \alias{print_list}
 \title{Return a list in R syntax}
 \usage{
-print_list(x, wrapper = TRUE, quote = FALSE)
+print_list(x, wrapper = TRUE)
 }
 \arguments{
 \item{x}{list to be printed}
 
 \item{wrapper}{wrap in list object?}
-
-\item{quote}{add quotes to values in list definition?}
 }
 \value{
 Original list in R syntax

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -8,8 +8,29 @@ test_that("now_utc returns time in UTC", {
   expect_equal(attr(now, "tzone"), "UTC")
 })
 
+test_that("print_list returns expected results", {
+  l1 <- list(x = 1, y = 2)
+  l2 <- list(x = 1, y = "foo")
+  l3 <- list(x = list(y = "foo"), z = "bar")
+  res1 <- print_list(l1)
+  res2 <- print_list(l2)
+  res3 <- print_list(l3)
+  expect_equal(res1, "list(x = 1, y = 2)")
+  expect_equal(res2, "list(x = 1, y = \"foo\")")
+  expect_equal(res3, "list(x = list(y = \"foo\"), z = \"bar\")")
+})
+
+test_that("print_list can remove outer list() call", {
+  l <- list(x = 1, y = 2)
+  expect_equal(print_list(l, wrapper = FALSE), "x = 1, y = 2")
+})
+
 test_that("print_list supports empty lists", {
   x <- list()
   res <- print_list(x)
   expect_equal(res, "")
+})
+
+test_that("print_list supports NULL input", {
+  expect_equal(print_list(NULL), "")
 })

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -21,8 +21,12 @@ test_that("print_list returns expected results", {
 })
 
 test_that("print_list can remove outer list() call", {
-  l <- list(x = 1, y = 2)
-  expect_equal(print_list(l, wrapper = FALSE), "x = 1, y = 2")
+  l1 <- list(x = 1, y = 2)
+  l2 <- list(formulation = c("a", "b"))
+  l3 <- list(x = list(y = list(z = 1)))
+  expect_equal(print_list(l1, wrapper = FALSE), "x = 1, y = 2")
+  expect_equal(print_list(l2, wrapper = FALSE), "formulation = c(\"a\", \"b\")")
+  expect_equal(print_list(l3, wrapper = FALSE), "x = list(y = list(z = 1))")
 })
 
 test_that("print_list supports empty lists", {


### PR DESCRIPTION
`print_list()`'s quoting behavior did not work well on nested lists:

```r
dat <- list(a = list(b = "foo"), c = "bar")
print_list(dat)
#> [1] "list (\"a\" = list(b = \"foo\"), \"c\" = bar)" # needs quotes around "bar" to be valid R syntax
print_list(dat, quote = TRUE)
#> [1] "list (\"a\" = \"list(b = \"foo\")\", \"c\" = \"bar\")" # quotes around the second list( shouldn't be there
``` 

It seems like this function only really worked well on lists that were a) not nested and b) all of the same type. A more flexible approach was to rewrite it using `capture.output()` and `dput()`. I was able to install all the model packages and run all our downstream f-tests after this change.

I've implemented this as an S3 method for lists and NULL values only, on the thinking that `dput()` output may not be a perfect representation of all types of objects, and if we start using this function for other objects we probably want to test it out carefully.
