### PR TITLE
RXR-1470: circumvent difference in how NONMEM and PKPDsim handle bioavailability for infusions

### DIFF
--- a/PKPDsim.Rproj
+++ b/PKPDsim.Rproj
@@ -17,5 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: No
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace

--- a/PKPDsim.Rproj
+++ b/PKPDsim.Rproj
@@ -17,6 +17,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: No
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -5,6 +5,7 @@
 #' @param n_ind repeat for `n_ind` subjects
 #' @param t_obs add observation time(s)
 #' @param obs_cmt observation compartment for added observation time(s)
+#' @param bioav bioavailability (numeric vector, can not be a parameter)
 #'
 #' @export
 #' @return Data frame containing doses
@@ -13,7 +14,9 @@ regimen_to_nm <- function(
   dose_cmt = 1,
   n_ind = 1,
   t_obs = NULL,
-  obs_cmt = 1) {
+  obs_cmt = 1,
+  bioav = NULL
+) {
   if(is.null(reg) || ! "regimen" %in% class(reg)) {
     stop("No regimen or invalid regimen object supplied.")
   }
@@ -27,6 +30,13 @@ regimen_to_nm <- function(
     MDV = 1))
   if(any(reg$type == "infusion")) {
     dat$RATE <- reg$dose_amts / reg$t_inf
+    if(!is.null(bioav)) {
+      bioav <- as.numeric(bioav)
+      if(!is.na(bioav) && bioav != 1) {
+        dat$RATE <- dat$RATE * bioav[dose_cmt]
+        warning("Recalculating infusion rates to reflect bioavailability for infusion.")
+      }
+    }
   }
   if(!is.null(t_obs)) {
     obs <- data.frame(

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -34,9 +34,11 @@ regimen_to_nm <- function(
       suppressWarnings(
         bioav_dose <- as.numeric(bioav[dose_cmt])
       )
-      if(!is.na(bioav_dose) && bioav_dose != 1) {
-        dat$RATE <- dat$RATE * bioav_dose
-        message("Recalculating infusion rates to reflect bioavailability for infusion.")
+      if(!is.na(bioav_dose)) {
+        if(bioav_dose != 1) {
+          dat$RATE <- dat$RATE * bioav_dose
+          message("Recalculating infusion rates to reflect bioavailability for infusion.")
+        }
       } else {
         warning("Bioavailability not specified correctly, cannot correct infusion rates.")
       }

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -31,9 +31,11 @@ regimen_to_nm <- function(
   if(any(reg$type == "infusion")) {
     dat$RATE <- reg$dose_amts / reg$t_inf
     if(!is.null(bioav[dose_cmt])) {
-      bioav <- as.numeric(bioav[dose_cmt])
-      if(!is.na(bioav[dose_cmt]) && bioav[dose_cmt] != 1) {
-        dat$RATE <- dat$RATE * bioav[dose_cmt]
+      suppressWarnings(
+        bioav_dose <- as.numeric(bioav[dose_cmt])
+      )
+      if(!is.na(bioav_dose) && bioav_dose != 1) {
+        dat$RATE <- dat$RATE * bioav_dose
         message("Recalculating infusion rates to reflect bioavailability for infusion.")
       } else {
         warning("Bioavailability not specified correctly, cannot correct infusion rates.")

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -30,11 +30,13 @@ regimen_to_nm <- function(
     MDV = 1))
   if(any(reg$type == "infusion")) {
     dat$RATE <- reg$dose_amts / reg$t_inf
-    if(!is.null(bioav)) {
-      bioav <- as.numeric(bioav)
-      if(!is.na(bioav) && bioav != 1) {
+    if(!is.null(bioav[dose_cmt])) {
+      bioav <- as.numeric(bioav[dose_cmt])
+      if(!is.na(bioav[dose_cmt]) && bioav[dose_cmt] != 1) {
         dat$RATE <- dat$RATE * bioav[dose_cmt]
-        warning("Recalculating infusion rates to reflect bioavailability for infusion.")
+        message("Recalculating infusion rates to reflect bioavailability for infusion.")
+      } else {
+        warning("Bioavailability not specified correctly, cannot correct infusion rates.")
       }
     }
   }

--- a/man/regimen_to_nm.Rd
+++ b/man/regimen_to_nm.Rd
@@ -4,7 +4,14 @@
 \alias{regimen_to_nm}
 \title{Convert PKPDsim regimen to NONMEM table (doses only)}
 \usage{
-regimen_to_nm(reg = NULL, dose_cmt = 1, n_ind = 1, t_obs = NULL, obs_cmt = 1)
+regimen_to_nm(
+  reg = NULL,
+  dose_cmt = 1,
+  n_ind = 1,
+  t_obs = NULL,
+  obs_cmt = 1,
+  bioav = NULL
+)
 }
 \arguments{
 \item{reg}{`PKPDsim` regimen, created using `new_regimen()` function}
@@ -16,6 +23,8 @@ regimen_to_nm(reg = NULL, dose_cmt = 1, n_ind = 1, t_obs = NULL, obs_cmt = 1)
 \item{t_obs}{add observation time(s)}
 
 \item{obs_cmt}{observation compartment for added observation time(s)}
+
+\item{bioav}{bioavailability (numeric vector, can not be a parameter)}
 }
 \value{
 Data frame containing doses

--- a/tests/testthat/test_regimen_to_nm.R
+++ b/tests/testthat/test_regimen_to_nm.R
@@ -15,3 +15,37 @@ test_that("regimen can be converted to nonmem format", {
   expect_true(all(expected_cols %in% colnames(b)))
 })
 
+test_that("regimen with infusion correctly recalculates rates when bioavailability specified", {
+  a <- new_regimen(amt = 10, n = 5, interval = 12, t_inf = 1, type = "infusion")
+  expect_message(
+    {
+      b <- regimen_to_nm(
+        a,
+        t_obs = c(1, 2, 3),
+        bioav = 0.5
+      )
+    },
+    "Recalculating infusion rates"
+  )
+  expect_warning(
+    regimen_to_nm(
+      a,
+      t_obs = c(1, 2, 3),
+      bioav = "F1"
+    ),
+    "Bioavailability not specified correctly"
+  )
+  expected_cols <- c(
+    "ID",
+    "TIME",
+    "CMT",
+    "DV",
+    "AMT",
+    "EVID",
+    "MDV",
+    "RATE"
+  )
+  expect_true(all(expected_cols %in% colnames(b)))
+  expect_equal(b$RATE, c(5, 0, 0, 0, 5, 5, 5, 5))
+})
+


### PR DESCRIPTION
PKPDsim automatically applies the bioavailability to infusions. NONMEM doesn’t do that, it instead recalculates duration as ((AMT/bioav)*rate), and then uses the given RATE to infuse. So for bioavailability of 10%, the duration will be 10 times shorter. But that's generally not really what one wants. The more intuitive way is to  just multiple RATE by bioavailability.

Generally we only have a bioavailability factor for oral models, which use a bolus into a dose compartment, so this issue will never surface. However, sometimes there is a use case for IV models too, e.g. when using it to convert unit from mg to mmol, or drug to prodrug. NONMEM's behavior with this scenario is also explained in the [RxODE manual](https://nlmixrdevelopment.github.io/RxODE-manual/events.html), as RxODE matches NONMEM's behavior.

To be clear, the behavior in PKPDsim was correct, and we’re not changing that. It’s just slightly different from NONMEM / RxODE, which IMO is less intuitive. Here, we're only updating the exporter to NONMEM datasets, so it matches behavior in PKPDsim and can be used for automated validations.