### PR TITLE
RXR-1539: bug: if link to "nonmem" file not defined in model, showing an uncaught warning

### DIFF
--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -340,7 +340,7 @@ new_ode_model <- function (model = NULL,
       } else {
         state_init <- add_quotes(state_init)
       }
-      if(is.null(nonmem)) { nonmem <- "NULL" }
+      if(is.null(nonmem) || length(nonmem) == 0) { nonmem <- "NULL" }
       if(is.null(int_step_size)) { int_step_size <- "NULL" }
       pars <- vector_to_R_code(reqd)
       covs <- vector_to_R_code(cov_names)


### PR DESCRIPTION
```
Warning message:
In matrix(c("\\[MODULE\\]", package, "\\[N_COMP\\]", size, "\\[OBS_COMP\\]",  :
  data length [55] is not a sub-multiple or multiple of the number of rows [28]
```

See command in JIRA ticket. No test needed, very minor fix.