### PR TITLE
RXR-1526: Only message about time for first covariate measurement if verbose

### DIFF
--- a/R/new_covariate.R
+++ b/R/new_covariate.R
@@ -110,7 +110,7 @@ new_covariate <- function(
     } else {
       # assume observation was at t=0
       new_times <- c(0, new_times[-1])
-      message("Note: time for first covariate measurement set to 0.")
+      if (verbose) message("Note: time for first covariate measurement set to 0.")
     }
   }
   if(length(new_unit) > length(new_values)) {


### PR DESCRIPTION
Elsewhere in the code we make messages conditional on the `verbose` argument. I've added that to this line to make this function quieter.