### PR TITLE
use LOCF when non-numeric too; check for implementation type

### DIFF
--- a/R/new_covariate.R
+++ b/R/new_covariate.R
@@ -2,13 +2,25 @@
 #'
 #' Describe data for a covariate, either fixed or time-variant
 #' @param value a numeric vector
-#' @param times NULL for time-invariant covariate or a numeric vector specifying the update times for the covariate
-#' @param implementation for time-varying covariates either 'LOCF' (last observation carried forward) or 'interpolate' (default)
-#' @param interpolation_join_limit for `interpolate` option, if covariate timepoints are spaced too close together, the ODE solver sometimes chokes. This argument sets a lower limit on the space between timepoints. It will create average values on joint timepoints instead. If undesired set to NULL or 0.
-#' @param unit specify covariate unit (optional, for documentation purposes only)
-#' @param remove_negative_times `TRUE`` or `FALSE`
-#' @param round_times round times to specified number of digits. If `NULL`, will not round.
-#' @param comments `NULL`, or vector of length equal to `value` specifying comments to each observation
+#' @param times NULL for time-invariant covariate or a numeric vector specifying
+#'   the update times for the covariate
+#' @param implementation for time-varying covariates either 'locf' (last
+#'   observation carried forward) or 'interpolate' (default). Non-numeric
+#'   covariate values are assumed to be locf.
+#' @param interpolation_join_limit for `interpolate` option, if covariate
+#'   timepoints are spaced too close together, the ODE solver sometimes chokes.
+#'   This argument sets a lower limit on the space between timepoints. It will
+#'   create average values on joint timepoints instead. If undesired set to
+#'   `NULL` or 0.
+#' @param unit specify covariate unit (optional, for documentation purposes
+#'   only)
+#' @param remove_negative_times should times before zero be discarded (with
+#'   value at time zero determined based on `implementation` argument), `TRUE`
+#'   or `FALSE`.
+#' @param round_times round times to specified number of digits. If `NULL`, will
+#'  not round.
+#' @param comments `NULL`, or vector of length equal to `value` specifying
+#'  comments to each observation (optional, for documentation only)
 #' @param verbose verbosity
 #' @export
 #' @return Object of class `"covariate"`
@@ -16,7 +28,7 @@
 new_covariate <- function(
   value = NULL,
   times = NULL,
-  implementation = "interpolate",
+  implementation = c("interpolate", "locf"),
   unit = NULL,
   interpolation_join_limit = 1,
   remove_negative_times = TRUE,
@@ -30,7 +42,15 @@ new_covariate <- function(
     times <- c(0)
     value <- value[1]
   }
-  implementation <- match.arg(tolower(implementation), c("interpolate", "locf"))
+  implementation <- tolower(implementation)
+  implementation <- match.arg(implementation, c("interpolate", "locf"))
+  if (mode(value) != "numeric" || is.factor(value)) {
+    if (implementation == "interpolate" && verbose) {
+      message("Non-numeric values cannot be interpolated. Switching to 'locf'.")
+    }
+    implementation <- "locf"
+    value <- as.character(value)
+  }
   srt <- order(times)
   times <- times[srt]
   values <- value[srt]
@@ -40,7 +60,7 @@ new_covariate <- function(
   } else {
     unit <- as.character(unit[srt])
   }
-  if(implementation == "interpolate" && inherits(values, "numeric") && !is.null(interpolation_join_limit) && interpolation_join_limit > 0) {
+  if(implementation == "interpolate" && isTRUE(interpolation_join_limit > 0)) {
     new_times <- c()
     new_values <- c()
     new_unit <- c()

--- a/man/new_covariate.Rd
+++ b/man/new_covariate.Rd
@@ -7,7 +7,7 @@
 new_covariate(
   value = NULL,
   times = NULL,
-  implementation = "interpolate",
+  implementation = c("interpolate", "locf"),
   unit = NULL,
   interpolation_join_limit = 1,
   remove_negative_times = TRUE,
@@ -19,19 +19,31 @@ new_covariate(
 \arguments{
 \item{value}{a numeric vector}
 
-\item{times}{NULL for time-invariant covariate or a numeric vector specifying the update times for the covariate}
+\item{times}{NULL for time-invariant covariate or a numeric vector specifying
+the update times for the covariate}
 
-\item{implementation}{for time-varying covariates either 'LOCF' (last observation carried forward) or 'interpolate' (default)}
+\item{implementation}{for time-varying covariates either 'locf' (last
+observation carried forward) or 'interpolate' (default). Non-numeric
+covariate values are assumed to be locf.}
 
-\item{unit}{specify covariate unit (optional, for documentation purposes only)}
+\item{unit}{specify covariate unit (optional, for documentation purposes
+only)}
 
-\item{interpolation_join_limit}{for \code{interpolate} option, if covariate timepoints are spaced too close together, the ODE solver sometimes chokes. This argument sets a lower limit on the space between timepoints. It will create average values on joint timepoints instead. If undesired set to NULL or 0.}
+\item{interpolation_join_limit}{for \code{interpolate} option, if covariate
+timepoints are spaced too close together, the ODE solver sometimes chokes.
+This argument sets a lower limit on the space between timepoints. It will
+create average values on joint timepoints instead. If undesired set to
+\code{NULL} or 0.}
 
-\item{remove_negative_times}{\verb{TRUE`` or }FALSE`}
+\item{remove_negative_times}{should times before zero be discarded (with
+value at time zero determined based on \code{implementation} argument), \code{TRUE}
+or \code{FALSE}.}
 
-\item{round_times}{round times to specified number of digits. If \code{NULL}, will not round.}
+\item{round_times}{round times to specified number of digits. If \code{NULL}, will
+not round.}
 
-\item{comments}{\code{NULL}, or vector of length equal to \code{value} specifying comments to each observation}
+\item{comments}{\code{NULL}, or vector of length equal to \code{value} specifying
+comments to each observation (optional, for documentation only)}
 
 \item{verbose}{verbosity}
 }

--- a/tests/testthat/test_new_covariate.R
+++ b/tests/testthat/test_new_covariate.R
@@ -61,4 +61,25 @@ test_that("Interpolated times are rounded properly", {
 })
 
 
+test_that("LOCF correctly implements non-numeric covs at t = 0", {
+  res1 <- new_covariate(
+    value = c("a", "b"),
+    times = c(-0.5, 48),
+    implementation = "LOCF",
+    remove_negative_times = TRUE
+  )
+  expect_equal(res1$value, c("a", "b"))
+  expect_equal(res1$times, c(0, 48))
+  res2 <- new_covariate(
+    value = c("a", "b"),
+    times = c(-0.5, 48),
+    implementation = "LOCF",
+    remove_negative_times = FALSE
+  )
+  expect_equal(res2$value, c("a", "b"))
+  expect_equal(res2$times, c(-0.5, 48))
+})
 
+test_that("implementation must be either locf or interpolate", {
+  expect_error(new_covariate(value = 1, implementation = "foo"))
+})

--- a/tests/testthat/test_new_covariate.R
+++ b/tests/testthat/test_new_covariate.R
@@ -82,4 +82,43 @@ test_that("LOCF correctly implements non-numeric covs at t = 0", {
 
 test_that("implementation must be either locf or interpolate", {
   expect_error(new_covariate(value = 1, implementation = "foo"))
+  # not case-sensitive:
+  expect_error(new_covariate(value = 1, implementation = "LOCF"), NA)
+  expect_equal(
+    new_covariate(value = 1, implementation = "LOCF"),
+    new_covariate(value = 1, implementation = "locf")
+  )
+})
+
+test_that("character/factor values are implemented via locf", {
+  v <- factor("a", levels = c("a", "b"))
+  expect_message(
+    new_covariate(value = "A", implementation = "interpolate", verbose = TRUE),
+    "Non-numeric values cannot be interpolated. Switching to 'locf'."
+  )
+  expect_message(
+    new_covariate(value = v, implementation = "interpolate", verbose = TRUE),
+    "Non-numeric values cannot be interpolated. Switching to 'locf'."
+  )
+  res1 <- new_covariate(
+    value = c("a", "b"),
+    times = c(-0.5, 48),
+    implementation = "interpolate",
+    verbose = FALSE
+  )
+  res2 <- new_covariate(
+    value = factor(c("a", "b"), levels = c("a", "b")),
+    times = c(-0.5, 48),
+    implementation = "interpolate",
+    verbose = FALSE
+  )
+  res3 <- new_covariate(
+    value = c("a", "b"),
+    times = c(-0.5, 48),
+    implementation = "LOCF"
+  )
+
+  expect_equal(res1, res3)
+  expect_equal(res2, res3)
+  expect_equal(res1$implementation, "locf")
 })


### PR DESCRIPTION
There was a unique situation that was not being handled correctly: 

- if the value supplied was non-numeric and 
- the `remove_negative_times` argument was `TRUE` (default), and 
- there were negative times, with the non-numeric value changing on either side of `t = 0`

then we were not actually carrying the last observation forward, but instead filtering the observations.

This is a pretty niche situation (`PKPDsim::sim`, the intended consumer of this data object requires numeric values) but when these values are used as placeholders for later use it was leading to some confusing results.

For safety, I also added a check to ensure the implementation method specified matches what we say in the documentation are the acceptable input types.