### PR TITLE
RXR-1771: Remove constraints on regimen type

### DIFF
--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -96,7 +96,7 @@ create_event_table <- function(
     regimen$evid <- c(rep(1, length(regimen$dose_times)), rep(2, length(covt$time)))
     regimen$dose_times <- c(regimen$dose_times, covt$time)
     regimen$dose_amts <- c(regimen$dose_amts, rep(0, length(covt$time)))
-    regimen$type <- c(regimen$type, rep(0, length(covt$time)))
+    regimen$type <- c(regimen$type, rep("covariate", length(covt$time)))
     regimen$dose_cmt <- c(regimen$dose_cmt, rep(0, length(covt$time)))
     regimen$t_inf <- c(regimen$t_inf, rep(0, length(covt$time)))
 
@@ -113,11 +113,13 @@ create_event_table <- function(
   }
 
   # parse list to a design (data.frame)
-  type <- (regimen$type == "infusion") * 1
-  regimen$t_inf[type == 0] <- 0 # make sure inf_time is 0 for boluses
+  # For boluses/oral, set infusion time to 0. For all other methods, assume
+  # infusion time was provided correctly
+  is_bolus <- regimen$type %in% c("oral", "bolus", "covariate")
+  regimen$t_inf[is_bolus] <- 0
   dos <- data.frame(cbind(t = regimen$dose_times,
                   dose = regimen$dose_amts,
-                  type = type,
+                  type = as.numeric(regimen$t_inf != 0),
                   dum = 0,
                   dose_cmt = regimen$dose_cmt,
                   t_inf = regimen$t_inf,
@@ -127,12 +129,12 @@ create_event_table <- function(
   if(sum(regimen$t_inf) > 0) {
     dos$rate[regimen$t_inf > 0] <- regimen$dose_amts[regimen$t_inf > 0] / regimen$t_inf[regimen$t_inf > 0]
   }
-  if(any(regimen$type == "infusion")) {
-    dos_t2 <- cbind(t = regimen$dose_times[regimen$type == "infusion"] + regimen$t_inf[regimen$type == "infusion"],
+  if(any(regimen$t_inf > 0)) {
+    dos_t2 <- cbind(t = regimen$dose_times[regimen$t_inf > 0] + regimen$t_inf[regimen$t_inf > 0],
                           dose = 0,
                           type = 1,
                           dum = 1,
-                          dose_cmt = regimen$dose_cmt[regimen$type == "infusion"],
+                          dose_cmt = regimen$dose_cmt[regimen$t_inf > 0],
                           t_inf = 0,
                           evid = 2,
                           bioav = 0, #bioav,
@@ -218,7 +220,7 @@ create_event_table <- function(
       }
     }
     # remove covariate points where there is also a dose
-    design <- design[!duplicated(paste0(design$t, "_", design$dose, "_", design$dum)),]
+    design <- design[!duplicated(paste(design$t, design$dose, design$dum, design$dose_cmt, sep = "_")),]
     # design <- design[!(design$t %in% covt$time & design$t %in% regimen$dose_times & design$dose == 0 & design$dum == 0) | design$t %in% t_obs,]
   }
   design <- design[design$t <= max(t_obs),]

--- a/R/new_regimen.R
+++ b/R/new_regimen.R
@@ -65,6 +65,9 @@ new_regimen <- function(
     if (is.null(times) && !is.null(interval) && is.null(n)) {
       stop("The number of doses (n) must be specified in the regimen object.")
     }
+    if (any(reg$type == "covariate")) {
+      stop("'covariate' is a protected type and cannot be used for doses.")
+    }
     if(any(type == "infusion") && (is.null(t_inf) || length(t_inf) == 0)) {
       reg$t_inf = 1
     } else if (any(is.na(t_inf))) {

--- a/R/new_regimen.R
+++ b/R/new_regimen.R
@@ -59,14 +59,6 @@ new_regimen <- function(
         reg$type <- "bolus"
       }
     }
-    if(!is.null(reg$type) && (any(is.null(reg$type)) || any(is.na(reg$type)) || any(length(reg$type) == 0) || !(all(reg$type %in% c("bolus", "oral", "infusion", "sc", "im"))))) {
-      if(!is.null(t_inf) || !is.null(rate)) {
-        reg$type <- "infusion" # assume all infusions
-      } else {
-        message("Type argument should be one of 'bolus', infusion', 'oral', 'sc' or 'im'. Assuming bolus for all doses.")
-        reg$type <- "bolus"
-      }
-    }
     if (is.null(times) && is.null(interval)) {
       stop("Dose times or dosing interval has to be specified.")
     }

--- a/tests/testthat/test_create_event_table.R
+++ b/tests/testthat/test_create_event_table.R
@@ -74,7 +74,7 @@ test_that("Rounding-related index matching issues in time col", {
   expect_equal(sum(is.na(res2$cov_PMA)), 0)
 })
 
-test_that("Multiple obs_types does not add erroneuous infusion stop events", {
+test_that("Multiple obs_types does not add erroneous infusion stop events", {
   reg <- new_regimen(
     amt = c(100, 100, 100, 100),
     times = c(0, 336, 672, 1008),
@@ -91,4 +91,26 @@ test_that("Multiple obs_types does not add erroneuous infusion stop events", {
     model = NULL
   )
   expect_true(all(cumsum(res$rate) >= 0)) # cumulative dose rate should never be lower than zero
+  expect_true(sum(res$rate) == 0) # net dose should always be zero
 })
+
+test_that("simulatenous doses in different cmts do not remove infusion stops", {
+  reg <- new_regimen(
+    amt = c(100, 10, 100, 10, 100, 10),
+    times = c(0, 0, 12, 12, 24, 24),
+    t_inf = 0.5,
+    type = rep(c("drug_1", "drug_2"), 3)
+  )
+  model <- mod_2cmt_iv
+  attr(model, "cmt_mapping") <- list(drug_1 = 1, drug_2 = 2)
+  res <- create_event_table(
+    regimen = reg,
+    t_obs = 36,
+    covariates = list(WT = new_covariate(value = c(50, 55), times = c(0, 20))),
+    model = model
+  )
+  expect_true(all(cumsum(res$rate) >= 0)) # cumulative dose rate should never be lower than zero
+  expect_true(sum(res$rate) == 0) # net dose should always be zero
+  expect_true(all((reg$dose_amts/reg$t_inf) %in% res$rate)) # rates are right
+})
+

--- a/tests/testthat/test_new_regimen.R
+++ b/tests/testthat/test_new_regimen.R
@@ -17,10 +17,6 @@ test_that("Regimen type parsed correctly", {
   expect_equal(reg_sc$type, rep("sc", 4))
   expect_equal(reg_im$type, rep("im", 4))
   expect_equal(reg_mixed$type, c("bolus", "infusion", "oral", "sc", "im"))
-  expect_message(
-    new_regimen(amt = 100, n = 3, interval = 4, type = c("bolus", "bolus", "blabla")),
-    "Type argument should be one of 'bolus', infusion', 'oral', 'sc' or 'im'. Assuming bolus for all doses."
-  )
 })
 
 test_that("Auto-detect infusion vs bolus", {
@@ -61,4 +57,9 @@ test_that("Doses < 0 set to 0", {
     tmp <- new_regimen(amt = c(-1, -2, 3, 4), times = c(0, 24, 48, 72), type = "infusion")
   )
   expect_true(all(tmp$dose_amts >= 0))
+})
+
+test_that("new_regimen can take arbitrary values for `type`", {
+  reg <- new_regimen(100, times = 0, type = "pip")
+  expect_equal(reg$type, "pip")
 })

--- a/tests/testthat/test_new_regimen.R
+++ b/tests/testthat/test_new_regimen.R
@@ -63,3 +63,7 @@ test_that("new_regimen can take arbitrary values for `type`", {
   reg <- new_regimen(100, times = 0, type = "pip")
   expect_equal(reg$type, "pip")
 })
+
+test_that("do not creat regimens of `type` 'covariate'", {
+  expect_error(new_regimen(100, times = 0, type = "covariate"))
+})


### PR DESCRIPTION
Removes logic that forces `type` to be one of 'bolus', infusion', 'oral', 'sc' or 'im'. If `type` is `NULL` we will still assume it's infusion if there's a `t_inf`, bolus otherwise.
