### PR TITLE
rm assumption non-inf types are t_inf = o

### DIFF
--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -119,7 +119,7 @@ create_event_table <- function(
   regimen$t_inf[is_bolus] <- 0
   dos <- data.frame(cbind(t = regimen$dose_times,
                   dose = regimen$dose_amts,
-                  type = as.numeric(!is_bolus),
+                  type = as.numeric(regimen$t_inf != 0),
                   dum = 0,
                   dose_cmt = regimen$dose_cmt,
                   t_inf = regimen$t_inf,

--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -220,7 +220,7 @@ create_event_table <- function(
       }
     }
     # remove covariate points where there is also a dose
-    design <- design[!duplicated(paste0(design$t, "_", design$dose, "_", design$dum)),]
+    design <- design[!duplicated(paste(design$t, design$dose, design$dum, design$dose_cmt, sep = "_")),]
     # design <- design[!(design$t %in% covt$time & design$t %in% regimen$dose_times & design$dose == 0 & design$dum == 0) | design$t %in% t_obs,]
   }
   design <- design[design$t <= max(t_obs),]

--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -96,7 +96,7 @@ create_event_table <- function(
     regimen$evid <- c(rep(1, length(regimen$dose_times)), rep(2, length(covt$time)))
     regimen$dose_times <- c(regimen$dose_times, covt$time)
     regimen$dose_amts <- c(regimen$dose_amts, rep(0, length(covt$time)))
-    regimen$type <- c(regimen$type, rep(0, length(covt$time)))
+    regimen$type <- c(regimen$type, rep("covariate", length(covt$time)))
     regimen$dose_cmt <- c(regimen$dose_cmt, rep(0, length(covt$time)))
     regimen$t_inf <- c(regimen$t_inf, rep(0, length(covt$time)))
 
@@ -115,7 +115,7 @@ create_event_table <- function(
   # parse list to a design (data.frame)
   # For boluses/oral, set infusion time to 0. For all other methods, assume
   # infusion time was provided correctly
-  is_bolus <- regimen$type %in% c("oral", "bolus")
+  is_bolus <- regimen$type %in% c("oral", "bolus", "covariate")
   regimen$t_inf[is_bolus] <- 0
   dos <- data.frame(cbind(t = regimen$dose_times,
                   dose = regimen$dose_amts,

--- a/R/new_regimen.R
+++ b/R/new_regimen.R
@@ -65,6 +65,9 @@ new_regimen <- function(
     if (is.null(times) && !is.null(interval) && is.null(n)) {
       stop("The number of doses (n) must be specified in the regimen object.")
     }
+    if (any(reg$type == "covariate")) {
+      stop("'covariate' is a protected type and cannot be used for doses.")
+    }
     if(any(type == "infusion") && (is.null(t_inf) || length(t_inf) == 0)) {
       reg$t_inf = 1
     } else if (any(is.na(t_inf))) {

--- a/tests/testthat/test_create_event_table.R
+++ b/tests/testthat/test_create_event_table.R
@@ -111,5 +111,6 @@ test_that("simulatenous doses in different cmts do not remove infusion stops", {
   )
   expect_true(all(cumsum(res$rate) >= 0)) # cumulative dose rate should never be lower than zero
   expect_true(sum(res$rate) == 0) # net dose should always be zero
+  expect_true(all((reg$dose_amts/reg$t_inf) %in% res$rate)) # rates are right
 })
 

--- a/tests/testthat/test_new_regimen.R
+++ b/tests/testthat/test_new_regimen.R
@@ -63,3 +63,7 @@ test_that("new_regimen can take arbitrary values for `type`", {
   reg <- new_regimen(100, times = 0, type = "pip")
   expect_equal(reg$type, "pip")
 })
+
+test_that("do not creat regimens of `type` 'covariate'", {
+  expect_error(new_regimen(100, times = 0, type = "covariate"))
+})


### PR DESCRIPTION
In create_event_table, two changes were necessary to enable simultaneous infusion-type doses in different compartments.

1) needed to assume that infusion doses could have a "type" other than "infusion". Changed logic to reference `t_inf`, assuming the user specified this correctly as non-zero.
2) needed to fix logic to also consider dose cmt when looking for duplicated rows

Added a test too