### PR TITLE
Fix `n` and length of rate vector in regimens joined by t_dose_update

### DIFF
--- a/R/join_regimen.R
+++ b/R/join_regimen.R
@@ -45,6 +45,8 @@ join_regimen <- function(
     regimen1$t_inf <- c(regimen1$t_inf[keep], regimen2$t_inf)
     regimen1$interval <- regimen2$interval
     regimen1$type <- c(regimen1$type[keep], regimen2$type)
+    regimen1$rate <- c(regimen1$rate[keep], regimen2$rate)
+    regimen1$n <- length(regimen1$dose_amts)
     return(regimen1)
   }
 

--- a/tests/testthat/test_join_regimen.R
+++ b/tests/testthat/test_join_regimen.R
@@ -74,3 +74,20 @@ test_that("join regimen works when no t_inf specified, e.g. oral or sc dosing", 
   expect_equal(reg$type, c("sc", "sc", "sc", "sc", "sc", "sc", "sc", "sc"))
   expect_equal(reg$dose_amts, c(500, 500, 500, 400, 400, 400, 400, 400))
 })
+
+test_that("join_regimen with t_dose_update maintains correct rate length", {
+  reg1 <- new_regimen(
+    amt = 1,
+    times = c(0, 24),
+    type = "oral"
+  )
+  reg2 <- new_regimen(
+    amt = 2,
+    time = c(0, 24, 48),
+    type = "oral"
+  )
+  reg3 <- join_regimen(reg1, reg2, t_dose_update = 24)
+
+  expect_equal(length(reg3$rate), length(reg3$dose_times))
+  expect_equal(reg3$n, 4)
+})


### PR DESCRIPTION
When joining regimens using `t_dose_update`, only the `rate` values from the first regimen were included, and the value in `n` was incorrect. This fixes both.