### PR TITLE
RXR-1953 modify function to calculate parameters to allow computation over time

### DIFF
--- a/R/calculate_parameters.R
+++ b/R/calculate_parameters.R
@@ -33,12 +33,12 @@ calculate_parameters <- function(
   if(is.null(regimen)) { # then just use dummy regimen.
     regimen <- new_regimen(amt = 0, times = 0, cmt = 1, type = "bolus")
   }
-  t_obs <- round(t_obs, 3)
   if(is.null(t_obs)) {
     t_obs_sim <- c(0, 1)
   } else {
-    t_obs_sim <- unique(c(0, t_obs))
+    t_obs_sim <- t_obs
   }
+  t_obs_sim <- round(t_obs_sim, 3)
   incl <- list(parameters = FALSE, variables = FALSE)
   if(!is.null(covariates)) covariates <- covariate_last_obs_only(covariates) # make sure only single value!
   if(include_parameters) incl$parameters <- TRUE
@@ -54,7 +54,10 @@ calculate_parameters <- function(
     only_obs = TRUE,
     ...
   )
-  res <- res[res$t %in% t_obs, ]
-  pars <- as.list(res[, -c(1:4)])
-  return(pars <- as.list(res[, -c(1:4)]))
+  if(!is.null(t_obs)) {
+    res <- res[res$t %in% t_obs_sim, ]
+  } else {
+    res <- res[nrow(res),]
+  }
+  return(as.list(res[, -c(1:4)]))
 }

--- a/R/calculate_parameters.R
+++ b/R/calculate_parameters.R
@@ -9,6 +9,12 @@
 #' @param ode PKPDsim model object
 #' @param parameters parameter list
 #' @param covariates covariate list. Make sure to include covariates at the right time point, since only last observed covariate values are used.
+#' @param regimen optional, provide a `regimen` object for the computation of
+#' the effective parameters. This is only relevant for models for which
+#' parameters depend on the dose or administration type, which is rare.
+#' @param t_obs optional, provide timepoint(s) at which to computate effective
+#' parameters. This is only relevant for models with time-varying fixed-effects.
+#' If unspecified, will evaluate parameters at `t=0`.
 #' @param include_parameters boolean, include parameters?
 #' @param include_variables boolean, include variables?
 #' @param ... arguments to pass on to simulation function
@@ -20,19 +26,35 @@ calculate_parameters <- function(
   covariates = NULL,
   include_parameters = TRUE,
   include_variables = TRUE,
+  regimen = NULL,
+  t_obs = NULL,
   ...
 ) {
-  reg <- new_regimen(amt = 0, times = 0, cmt = 1, type = "bolus")
+  if(is.null(regimen)) { # then just use dummy regimen.
+    regimen <- new_regimen(amt = 0, times = 0, cmt = 1, type = "bolus")
+  }
+  t_obs <- round(t_obs, 3)
+  if(is.null(t_obs)) {
+    t_obs_sim <- c(0, 1)
+  } else {
+    t_obs_sim <- unique(c(0, t_obs))
+  }
   incl <- list(parameters = FALSE, variables = FALSE)
   if(!is.null(covariates)) covariates <- covariate_last_obs_only(covariates) # make sure only single value!
   if(include_parameters) incl$parameters <- TRUE
   if(include_variables) incl$variables <- TRUE
-  res <- sim_ode(ode = ode,
-                 parameters = parameters,
-                 regimen = reg,
-                 omega = NULL,
-                 covariates = covariates,
-                 output_include = incl,
-                 t_obs = c(0,1), only_obs = TRUE, ...) %>% utils::tail(1)
-  return(pars <- as.list(res[,-c(1:4)]))
+  res <- sim_ode(
+    ode = ode,
+    parameters = parameters,
+    regimen = regimen,
+    omega = NULL,
+    covariates = covariates,
+    output_include = incl,
+    t_obs = t_obs_sim,
+    only_obs = TRUE,
+    ...
+  )
+  res <- res[res$t %in% t_obs, ]
+  pars <- as.list(res[, -c(1:4)])
+  return(pars <- as.list(res[, -c(1:4)]))
 }

--- a/man/calculate_parameters.Rd
+++ b/man/calculate_parameters.Rd
@@ -10,6 +10,8 @@ calculate_parameters(
   covariates = NULL,
   include_parameters = TRUE,
   include_variables = TRUE,
+  regimen = NULL,
+  t_obs = NULL,
   ...
 )
 }
@@ -23,6 +25,14 @@ calculate_parameters(
 \item{include_parameters}{boolean, include parameters?}
 
 \item{include_variables}{boolean, include variables?}
+
+\item{regimen}{optional, provide a `regimen` object for the computation of
+the effective parameters. This is only relevant for models for which
+parameters depend on the dose or administration type, which is rare.}
+
+\item{t_obs}{optional, provide timepoint at which to computate effective
+parameters. This is only relevant for models with time-varying fixed-effects.
+If unspecified, will evaluate parameters at `t=0`.}
 
 \item{...}{arguments to pass on to simulation function}
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,9 +1,13 @@
 mod_1cmt_iv <- new_ode_model("pk_1cmt_iv")
 mod_2cmt_iv <- new_ode_model("pk_2cmt_iv")
 mod_1cmt_oral <- new_ode_model("pk_1cmt_oral")
-oral_1cmt_allometric <- new_ode_model(
+oral_1cmt_allometric <- new_ode_model( # also timevarying factor
   code = "
-      CLi = CL * pow(WT/70, 0.75)
+      if(t<168.0) {
+        CLi = CL * pow(WT/70, 0.75)
+      } else {
+        CLi = CL * pow(WT/70, 0.75) * 1.5
+      }
       dAdt[1] = -KA * A[1]
       dAdt[2] = KA*A[1] - (CLi/V)*A[2]
     ",

--- a/tests/testthat/test_calc_parameters.R
+++ b/tests/testthat/test_calc_parameters.R
@@ -49,3 +49,19 @@ test_that("Works if no covariates", {
   expect_true(all(c(expect_pars, expect_vars) %in% names(eff2)))
   expect_equal(eff2$CL, pars$CL)
 })
+
+test_that("Works when t_obs specified for timevarying model", {
+  # model defined in setup.R, with CLi = CL * pow(WT/70, 0.75), and x1.5 after 168 hrs
+  covs1 <- list(WT = new_covariate(50))
+  pars <- list(KA = 0.5, CL = 5, V = 50)
+  eff1 <- calculate_parameters(oral_1cmt_allometric, pars, covs1, t_obs = c(20, 40, 200))
+  expect_pars <- attr(oral_1cmt_allometric, "parameters")
+  expect_vars <- attr(oral_1cmt_allometric, "variables")
+  expect_true(all(c(expect_pars, expect_vars) %in% names(eff1)))
+  CL1 <- pars$CL * (covs1$WT$value / 70) ** 0.75
+  CL2 <- CL1 * 1.5
+  expect_equal(
+    eff1$CLi,
+    c(CL1, CL1, CL2)
+  )
+})


### PR DESCRIPTION
The convenience function calculate_parameters() is intended to quickly calculate the effective parameters for a given model and covariates. However, some models have time-varying parameter definitions. To allow computations of effective parameters over time, I've now added a `t_obs` argument, which then returns each parameter as a vector of values instead of a single value.