### PR TITLE
add informative error message to facilitate debugging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ License: MIT + file LICENSE
 URL: https://github.com/InsightRX/PKPDsim,
     https://insightrx.github.io/PKPDsim/
 LazyData: TRUE
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Config/Needs/website: tidyverse, nlmixr2
 Encoding: UTF-8

--- a/R/PKPDsim-package.R
+++ b/R/PKPDsim-package.R
@@ -2,11 +2,10 @@
 #'
 #' Simulate regimens for PKPD models defined by ODE systems
 #'
-#' @docType package
 #' @name PKPDsim-package
 #' @author Ron Keizer \email{ronkeizer@@gmail.com}
 #' @importFrom utils packageVersion tail
 #' @importFrom stats aggregate qnorm quantile reshape rnorm
 #' @importFrom magrittr `%>%`
 #' @keywords internal
-NULL
+"_PACKAGE"

--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -46,6 +46,13 @@ create_event_table <- function(
 
   } else if (!is.null(model) && !is.null(attr(model, "cmt_mapping"))) {
     cmt_mapping <- attr(model, "cmt_mapping")
+    if (!all(regimen$type %in% names(cmt_mapping))) {
+      stop(
+        "Unrecognized regimen type. Define '",
+        setdiff(regimen$type, names(cmt_mapping)),
+        "' in model md field `cmt_mapping`"
+      )
+    }
     regimen$dose_cmt <- vapply(regimen$type, function(x) cmt_mapping[[x]], FUN.VALUE = numeric(1), USE.NAMES = FALSE)
 
   } else {

--- a/man/PKPDsim-package.Rd
+++ b/man/PKPDsim-package.Rd
@@ -2,10 +2,19 @@
 % Please edit documentation in R/PKPDsim-package.R
 \docType{package}
 \name{PKPDsim-package}
+\alias{PKPDsim}
 \alias{PKPDsim-package}
 \title{PKPDsim package}
 \description{
 Simulate regimens for PKPD models defined by ODE systems
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/InsightRX/PKPDsim}
+  \item \url{https://insightrx.github.io/PKPDsim/}
+}
+
 }
 \author{
 Ron Keizer \email{ronkeizer@gmail.com}

--- a/tests/testthat/test_create_event_table.R
+++ b/tests/testthat/test_create_event_table.R
@@ -114,6 +114,27 @@ test_that("simulatenous doses in different cmts do not remove infusion stops", {
   expect_true(all((reg$dose_amts/reg$t_inf) %in% res$rate)) # rates are right
 })
 
+test_that("useful cmt_mapping mismatch error is thrown", {
+  reg <- new_regimen(
+    amt = 100,
+    times = c(0, 12, 24),
+    t_inf = 0,
+    type = rep("oral", 3)
+  )
+  model <- mod_2cmt_iv
+  attr(model, "cmt_mapping") <- list(infusion = 1, bolus = 1) # not oral
+  expect_error(
+    create_event_table(
+      regimen = reg,
+      t_obs = 36,
+      covariates = list(WT = new_covariate(value = c(50, 55), times = c(0, 20))),
+      model = model
+    ),
+    "Unrecognized regimen type. Define 'oral' in model md field `cmt_mapping`",
+    fixed = TRUE
+  )
+})
+
 test_that("sc, im are considered to have t_inf = 0", {
   reg1 <- new_regimen(
     amt = c(100, 100),


### PR DESCRIPTION
I was running a simulation and encountered an uninformative error message. I was able to track down the source but it took me a while since the error was very generic:

>Error in vapply(regimen$type, function(x) cmt_mapping[[x]], FUN.VALUE = numeric(1),  : 
  values must be length 1,
 but FUN(X[[1]]) result is length 0

Having this extra check and more informative error message would have saved me some time.

