### PR TITLE
ensure paths with spaces are parsed properly

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,9 +34,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
       
-      - name: Install curl
-        run: sudo apt-get install -y libcurl4-openssl-dev
-
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
           #- {os: macos-latest,   r: 'release'}
-          #- {os: windows-latest, r: 'release'}
           #- {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           
           

--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -459,14 +459,14 @@ new_ode_model <- function (model = NULL,
           "--with-keep.source",
           "--pkglock",
           "--no-staged-install",
-          normalizePath(file.path(folder, package))
+          shQuotes(normalizePath(file.path(folder, package)))
         )
 
         system2(cmd, args, stdout = quiet, stderr = quiet)
 
       } else {
         # Run R CMD BUILD to zip file
-        args <- c("CMD", "build", normalizePath(file.path(folder, package)))
+        args <- c("CMD", "build", shQuotes(normalizePath(file.path(folder, package))))
         system2(cmd, args, stdout = quiet, stderr = quiet)
         pkg_file <- paste0(package, "_", version, ".tar.gz")
         if(file.exists(pkg_file)) {

--- a/R/new_ode_model.R
+++ b/R/new_ode_model.R
@@ -459,14 +459,14 @@ new_ode_model <- function (model = NULL,
           "--with-keep.source",
           "--pkglock",
           "--no-staged-install",
-          shQuotes(normalizePath(file.path(folder, package)))
+          shQuote(normalizePath(file.path(folder, package)))
         )
 
         system2(cmd, args, stdout = quiet, stderr = quiet)
 
       } else {
         # Run R CMD BUILD to zip file
-        args <- c("CMD", "build", shQuotes(normalizePath(file.path(folder, package))))
+        args <- c("CMD", "build", shQuote(normalizePath(file.path(folder, package))))
         system2(cmd, args, stdout = quiet, stderr = quiet)
         pkg_file <- paste0(package, "_", version, ".tar.gz")
         if(file.exists(pkg_file)) {


### PR DESCRIPTION
The command
```
PKPDsim::install_default_literature_model("pk_busulfan_mccune")
```
wasn't working because in `new_ode_model()` it tried to run a command like
```
R CMD INSTALL --arg1 --arg2 C:\Users\User name\etc
```
So the space in the path actually split that argument into two arguments, and hence made the installation fail. The fix just adds double-quotes around that argument to ensure it is parsed as a single argument. After this, the package installed fine. 

Hopefully this fixes the issue (https://github.com/InsightRX/mipdtrial/actions/runs/9473553934/job/26101414203) with mipdtrial, although from the error there it doesn't seem like that path actually contained a space...

The change shouldn't affect behavior on Linux or Mac, in fact it is safer there too.