### PR TITLE
RXR-2140: fix issue due to change in warning behavior in upcoming Rcpp

### DIFF
--- a/R/sim.R
+++ b/R/sim.R
@@ -189,6 +189,11 @@ sim <- function (ode = NULL,
         p <- parameters
       }
     }
+    if(!is.null(attr(ode, "iov")$n_bins) && attr(ode, "iov")$n_bins > 1) {
+      if(attr(ode, "iov")$n_bins != (length(iov_bins)-1)) {
+        warning("Number of IOV bins specified for model does not match supplied `iov_bins` argument. This could lead to simulation failures or erroneous output.")
+      }
+    }
     if(is.null(analytical)) {
       if(inherits(ode, "function") && !isTRUE(attr(ode, "cpp"))) {
         stop("Sorry. Non-C++ functions are deprecated as input for ODE.")

--- a/tests/testthat/test_iov.R
+++ b/tests/testthat/test_iov.R
@@ -52,28 +52,32 @@ test_that("Throws warning when `iov_bins` length doesn't match number of specifi
       only_obs = TRUE,
       output_include = list(parameters = TRUE, variables = TRUE)
     )
-  })
-  expect_warning({
+  }, "Number of IOV bins specified")
+  Rcpp_v <- unlist(packageVersion("Rcpp"))
+  if(Rcpp_v[1] >= 1 && Rcpp_v[2] >= 0 && Rcpp_v[3] >= 12 && Rcpp_v[4] >= 4) {
+    ## if-statement can be removed when Rcpp on CRAN >= 1.0.12.4
     expect_warning({
-      sim(
-        ode = pk1,
-        parameters = pars,
-        regimen = reg1,
-        omega = c(
-          iov_var, # IOV in CL
-          0, iov_var,
-          0, 0, iov_var,
-          0, 0, 0, iov_var,
-          0, 0, 0, 0, 0.3 # IIV in CL
-        ),
-        n = 1,
-        iov_bins = c(0, 24, 999), # one bin too few
-        omega_type = "normal",
-        only_obs = TRUE,
-        output_include = list(parameters = TRUE, variables = TRUE)
-      )
-    }, "Number of IOV bins specified")
-  }, "subscript out of bounds")
+      expect_warning({
+        sim(
+          ode = pk1,
+          parameters = pars,
+          regimen = reg1,
+          omega = c(
+            iov_var, # IOV in CL
+            0, iov_var,
+            0, 0, iov_var,
+            0, 0, 0, iov_var,
+            0, 0, 0, 0, 0.3 # IIV in CL
+          ),
+          n = 1,
+          iov_bins = c(0, 24, 999), # one bin too few
+          omega_type = "normal",
+          only_obs = TRUE,
+          output_include = list(parameters = TRUE, variables = TRUE)
+        )
+      }, "Number of IOV bins specified")
+    }, "subscript out of bounds") # only thrown when Rcpp >= 1.0.12.4
+  }
 })
 
 test_that("IOV is added to parameters", {

--- a/tests/testthat/test_iov.R
+++ b/tests/testthat/test_iov.R
@@ -2,12 +2,12 @@ pars <- list(
   "kappa_CL_1" = 0,
   "kappa_CL_2" = 0,
   "kappa_CL_3" = 0,
-  "kappa_CL_4" = 0,
   "eta_CL" = 0,
   "CL" = 5,
   "V" = 50,
   "KA" = 1
 )
+
 pk1 <- new_ode_model(
   code = "
       CL_iov = CL * exp(kappa_CL + eta_CL);
@@ -16,7 +16,7 @@ pk1 <- new_ode_model(
     ",
   iov = list(
     cv = list(CL = 0.2),
-    n_bins = 4
+    n_bins = 3
   ),
   obs = list(cmt = 2, scale = "V"),
   dose = list(cmt = 1, bioav = 1),
@@ -32,6 +32,49 @@ reg1 <- new_regimen(
   type = "infusion"
 )
 iov_var <- 0.3 ^ 2 # 30% IOV
+
+test_that("Throws warning when `iov_bins` length doesn't match number of specified bins", {
+  expect_warning({
+    sim(
+      ode = pk1,
+      parameters = pars,
+      regimen = reg1,
+      omega = c(
+        iov_var, # IOV in CL
+        0, iov_var,
+        0, 0, iov_var,
+        0, 0, 0, iov_var,
+        0, 0, 0, 0, 0.3 # IIV in CL
+      ),
+      n = 1,
+      iov_bins = c(0, 24, 48, 72, 999), # one bin too many
+      omega_type = "normal",
+      only_obs = TRUE,
+      output_include = list(parameters = TRUE, variables = TRUE)
+    )
+  })
+  expect_warning({
+    expect_warning({
+      sim(
+        ode = pk1,
+        parameters = pars,
+        regimen = reg1,
+        omega = c(
+          iov_var, # IOV in CL
+          0, iov_var,
+          0, 0, iov_var,
+          0, 0, 0, iov_var,
+          0, 0, 0, 0, 0.3 # IIV in CL
+        ),
+        n = 1,
+        iov_bins = c(0, 24, 999), # one bin too few
+        omega_type = "normal",
+        only_obs = TRUE,
+        output_include = list(parameters = TRUE, variables = TRUE)
+      )
+    }, "Number of IOV bins specified")
+  }, "subscript out of bounds")
+})
 
 test_that("IOV is added to parameters", {
   skip_on_cran()
@@ -95,7 +138,7 @@ test_that("Change in F in 2nd bin is applied in 2nd bin and not later.", {
     ",
     iov = list(
       cv = list(F = 0.2),
-      n_bins = 4
+      n_bins = 3
     ),
     obs = list(cmt = 2, scale = "V"),
     dose = list(cmt = 1, bioav = "Fi"),
@@ -181,5 +224,4 @@ test_that("error is not invoked when using parameters_table", {
       output_include = list(parameters = TRUE, variables = TRUE)
     )
   )
-
 })

--- a/tests/testthat/test_iov.R
+++ b/tests/testthat/test_iov.R
@@ -54,7 +54,7 @@ test_that("Throws warning when `iov_bins` length doesn't match number of specifi
     )
   }, "Number of IOV bins specified")
   Rcpp_v <- unlist(packageVersion("Rcpp"))
-  if(Rcpp_v[1] >= 1 && Rcpp_v[2] >= 0 && Rcpp_v[3] >= 12 && Rcpp_v[4] >= 4) {
+  if(Rcpp_v[1] >= 1 && Rcpp_v[2] >= 0 && (Rcpp_v[3] >= 13 || isTRUE(Rcpp_v[3] >= 12 && Rcpp_v[4] >= 4))) {
     ## if-statement can be removed when Rcpp on CRAN >= 1.0.12.4
     expect_warning({
       expect_warning({


### PR DESCRIPTION
See description of [change in Rcpp](https://github.com/RcppCore/Rcpp/issues/1311#user-content-fn-1-1400efc2b2c5361907ad0f063feeeb20).

The failure in PKPDsim test was due to an erroneously configured test case, which had the wrong number of bins for simulation of inter-occasion variability. This led to extra warnings using the new Rcpp. This PR fixes the test case. 

It also adds an extra warning to make it harder to misconfigure the number of IOV bins (and a new test to confirm the warning is thrown). I did not make that a hard stop(), because in most cases the misconfiguration is not affecting the results.

For reviewing this PR: 
1. first run tests using old version of Rcpp (anything before 1.0.12.4). The tests should all run fine, either on master or on this branch.
2. then install latests version on `Rcpp/main` using `remotes::install("RcppCore/Rcpp")`. Then rerun tests. The tests should fail on the `PKPDsim/master` branch, but not on `PKPDsim/RXR-2140-Rcpp-issue`.
