### PR TITLE
Update Dockerfile to Use Rocker R Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM 579831337053.dkr.ecr.us-west-2.amazonaws.com/irx-r-base:latest
+FROM rocker/r-ver:latest
 
 ENV _R_CHECK_TESTS_NLINES_=0
 
-RUN rm -rf /src/PKPDsim
-COPY ./ /src/PKPDsim
 WORKDIR /src/PKPDsim
 
-# Install system and CRAN dependencies
-RUN apt-get update
-RUN apt install -y pandoc qpdf
-RUN Rscript -e "install.packages(c('mockery', 'nlmixr2', 'knitr', 'rmarkdown'), repos = '${RSPM_SNAPSHOT}')"
+COPY ./ /src/PKPDsim
+
+RUN apt-get update && apt-get install -y \
+    pandoc \
+    qpdf \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN Rscript -e "install.packages(c('mockery', 'nlmixr2', 'knitr', 'rmarkdown'), repos = 'https://cloud.r-project.org')"
+
+RUN R CMD check PKPDsim

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+    
 RUN Rscript -e "install.packages(c('mockery', 'nlmixr2', 'knitr', 'rmarkdown'), repos = 'https://cloud.r-project.org')"
 
 RUN R CMD check PKPDsim
+

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -1,0 +1,12 @@
+FROM 579831337053.dkr.ecr.us-west-2.amazonaws.com/irx-r-base:latest
+
+ENV _R_CHECK_TESTS_NLINES_=0
+
+RUN rm -rf /src/PKPDsim
+COPY ./ /src/PKPDsim
+WORKDIR /src/PKPDsim
+
+# Install system and CRAN dependencies
+RUN apt-get update
+RUN apt install -y pandoc qpdf
+RUN Rscript -e "install.packages(c('mockery', 'nlmixr2', 'knitr', 'rmarkdown'), repos = '${RSPM_SNAPSHOT}')"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  pkpdsim:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: pkpdsim:latest
+
+  pkpdsim-aws:
+    build:
+      context: .
+      dockerfile: Dockerfile.aws
+    image: pkpdsim:aws
+
+# docker-compose build
+# docker-compose build pkpdsim
+# docker-compose build pkpdsim-aws
+# docker-compose run pkpdsim
+# docker-compose run pkpdsim-aws


### PR DESCRIPTION
# Update Dockerfile to Use Rocker R Image

## Summary
This PR updates the Dockerfile to use the public `rocker/r-ver` image instead of the previously specified private image. This change simplifies the build process by using a widely-available base image specifically designed for R, which is maintained by the R community.

## Changes Made
1. **Base Image Update**:
   - Changed the base image to `rocker/r-ver:latest`. This image is optimized for R and maintained by the Rocker Project, ensuring compatibility and ease of use.

2. **System Dependencies**:
   - Added installation commands for system dependencies `pandoc` and `qpdf` required by the package.
   - Included clean-up commands to reduce the final image size.

3. **CRAN Packages Installation**:
   - Added commands to install necessary CRAN packages (`mockery`, `nlmixr2`, `knitr`, `rmarkdown`) from the cloud repository.

4. **Working Directory**:
   - Set the working directory to `/src/PKPDsim` and copied the package content into this directory.

## Benefits
- **Simplified Build Process**: Using a public and well-maintained base image reduces complexity.
- **Compatibility**: Ensures compatibility with R and related tools, as the Rocker images are specifically tailored for R.
- **Community Support**: Leveraging the Rocker Project's images means benefiting from community support and regular updates.

reserved earlier Dockerfile content as Dockerfile.aws which could be build and run as  `docker-compose build pkpdsim-aws`

```bash
  docker-compose build
  docker-compose build pkpdsim
  docker-compose build pkpdsim-aws
  docker-compose run pkpdsim
  docker-compose run pkpdsim-aws
```
