### PR TITLE
RXR-1876 fix warning infusion

### DIFF
--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -37,14 +37,15 @@ regimen_to_nm <- function(
       suppressWarnings(
         bioav_dose <- as.numeric(bioav[dose_cmt])
       )
-      if(!any(is.na(bioav_dose))) {
-        if(!all(bioav_dose == 1)) {
-          dat$RATE <- dat$RATE * bioav_dose
-          message("Recalculating infusion rates to reflect bioavailability for infusion.")
+      non_na_biov_dose <- !is.na(bioav_dose)
+      if(any(is.na(bioav_dose))) {
+        if(any(is.na(bioav_dose) & reg$t_inf > 0)) { # only warn when it actually concerns an infusion
+          warning("For compartments where bioavailability is specified as model parameter and not as a number, any infusion rates are not corrected for bioavailability.")
         }
-      } else {
-        warning("Bioavailability not specified correctly, cannot correct infusion rates.")
+        bioav_dose[is.na(bioav_dose)] <- 1
       }
+      dat$RATE <- dat$RATE * bioav_dose
+      message("Recalculating infusion rates to reflect bioavailability for infusion.")
     }
   }
   if(!is.null(t_obs)) {

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -37,7 +37,6 @@ regimen_to_nm <- function(
       suppressWarnings(
         bioav_dose <- as.numeric(bioav[dose_cmt])
       )
-      non_na_biov_dose <- !is.na(bioav_dose)
       if(any(is.na(bioav_dose))) {
         if(any(is.na(bioav_dose) & reg$t_inf > 0)) { # only warn when it actually concerns an infusion
           warning("For compartments where bioavailability is specified as model parameter and not as a number, any infusion rates are not corrected for bioavailability.")

--- a/tests/testthat/test_regimen_to_nm.R
+++ b/tests/testthat/test_regimen_to_nm.R
@@ -33,7 +33,7 @@ test_that("regimen with infusion correctly recalculates rates when bioavailabili
       t_obs = c(1, 2, 3),
       bioav = "F1"
     ),
-    "Bioavailability not specified correctly"
+    "For compartments where bioavailability is specified"
   )
   expected_cols <- c(
     "ID",
@@ -95,3 +95,34 @@ test_that("rate is calculated for any regimen with an infusion length", {
   expect_equal(c$RATE, c(0, 0, 0, 0, 0, 10, 20, 0))
 })
 
+test_that("throws warning when bioav specified as model parameter and need to convert RATE, but not when not needed", {
+  a <- new_regimen(
+    amt = 10,
+    time = c(1, 2, 3, 4),
+    t_inf = c(0, 0, 1, 1),
+    type = c("oral", "oral", "infusion", "infusion")
+  )
+  expect_message({
+    b <- regimen_to_nm(
+      a,
+      dose_cmt = c(1, 1, 2, 2),
+      t_obs = c(1, 2, 3),
+      bioav = c("Fi", 1)
+    )
+  }, "Recalculating infusion rates")
+  a2 <- new_regimen(
+    amt = 10,
+    time = c(1, 2, 3, 4),
+    t_inf = c(1, 1, 1, 1),  # now an infusion in the sc compartment and infusion lengths are >0, should throw warning!
+    type = c("sc", "sc", "infusion", "infusion")
+  )
+  expect_warning(
+    regimen_to_nm(
+      a2,
+      dose_cmt = c(1, 1, 2, 2),
+      t_obs = c(1, 2, 3),
+      bioav = c("Fi", 1)
+    ),
+    "For compartments where bioavailability is specified"
+  )
+})


### PR DESCRIPTION
Refactor of the logic around throwing a warning around infusion rates. This was throwing a harmless but unnecessary warning during automated model validations for some models.

The logic was too strict, it was also thrown for regimens where infusion rates were not relevant. The logic is updated and simplified, as well as the warning text. Also added a test (there was already one test, updated that one too). The warning 
is not thrown any more in the model validation where it occurred before.