### PR TITLE
RXR-2378 bug with Fi defined in ode producing NA concentrations

### DIFF
--- a/R/apply_lagtime.R
+++ b/R/apply_lagtime.R
@@ -13,17 +13,17 @@ apply_lagtime <- function(
   parameters,
   cmt_mapping = NULL
 ) {
-    regimen$nominal_dose_times <- regimen$dose_times # keep original dose_times available
+    regimen$effective_dose_times <- regimen$dose_times # dose times with lag times added
     if(class(lagtime) %in% c("numeric", "integer")) {
       if(length(lagtime) == 1) {
-        regimen$dose_times <- regimen$dose_times + lagtime
+        regimen$effective_dose_times <- regimen$dose_times + lagtime
       } else {
-        regimen$dose_times <- regimen$dose_times + lagtime[regimen$cmt]
+        regimen$effective_dose_times <- regimen$dose_times + lagtime[regimen$cmt]
       }
     }
     if(class(lagtime) %in% c("character")) {
       if(length(lagtime) == 1) {
-        regimen$dose_times <- regimen$dose_times + parameters[[lagtime]]
+        regimen$effective_dose_times <- regimen$dose_times + parameters[[lagtime]]
       } else {
         if(is.null(regimen$cmt)) {
           if(!is.null(cmt_mapping)) {
@@ -34,7 +34,7 @@ apply_lagtime <- function(
         }
         par_tmp <- parameters
         par_tmp[["0"]] <- 0
-        regimen$dose_times <- regimen$dose_times + as.numeric(unlist(par_tmp[lagtime[regimen$cmt]]))
+        regimen$effective_dose_times <- regimen$dose_times + as.numeric(unlist(par_tmp[lagtime[regimen$cmt]]))
       }
     }
     return(regimen)

--- a/R/apply_lagtime.R
+++ b/R/apply_lagtime.R
@@ -13,6 +13,7 @@ apply_lagtime <- function(
   parameters,
   cmt_mapping = NULL
 ) {
+    regimen$nominal_dose_times <- regimen$dose_times # keep original dose_times available
     if(class(lagtime) %in% c("numeric", "integer")) {
       if(length(lagtime) == 1) {
         regimen$dose_times <- regimen$dose_times + lagtime

--- a/R/sim.R
+++ b/R/sim.R
@@ -147,6 +147,8 @@ sim <- function (ode = NULL,
   }
   if(!is.null(lagtime)) {
     regimen <- apply_lagtime(regimen, lagtime, parameters, attr(ode, "cmt_mapping"))
+  } else {
+    regimen$nominal_dose_times <- regimen$dose_times
   }
   if(!is.null(attr(ode, "dose")$duration_scale)) {
     regimen <- apply_duration_scale(
@@ -341,6 +343,7 @@ sim <- function (ode = NULL,
     }
     design_i <- design
     p$dose_times <- regimen$dose_times
+    p$nominal_dose_times <- regimen$nominal_dose_times
     p$dose_amts  <- regimen$dose_amts
   }
 

--- a/R/sim.R
+++ b/R/sim.R
@@ -148,7 +148,7 @@ sim <- function (ode = NULL,
   if(!is.null(lagtime)) {
     regimen <- apply_lagtime(regimen, lagtime, parameters, attr(ode, "cmt_mapping"))
   } else {
-    regimen$nominal_dose_times <- regimen$dose_times
+    regimen$effective_dose_times <- regimen$dose_times
   }
   if(!is.null(attr(ode, "dose")$duration_scale)) {
     regimen <- apply_duration_scale(
@@ -343,7 +343,7 @@ sim <- function (ode = NULL,
     }
     design_i <- design
     p$dose_times <- regimen$dose_times
-    p$nominal_dose_times <- regimen$nominal_dose_times
+    p$effective_dose_times <- regimen$effective_dose_times
     p$dose_amts  <- regimen$dose_amts
   }
 

--- a/inst/cpp/sim.cpp
+++ b/inst/cpp/sim.cpp
@@ -50,18 +50,6 @@ void pk_code (int i, std::vector<double> times, std::vector<double> doses, doubl
   // insert custom pk event code
 }
 
-int find_first_nonzero(std::vector<double> vect) {
-  // find first nonzero value in vector, returns first value if non found
-  int index = 0;
-  for(int i = 0; i < vect.size(); i++) {
-    if(vect[i] > 0) {
-      index = i;
-      break;
-    }
-  }
-  return(index);
-}
-
 // [[Rcpp::export]]
 List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_bins, double step_size) {
   std::vector<double> t;
@@ -93,9 +81,10 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
   // insert A dAdt state_init
   set_covariates(0);
 
-  // set prv_dose to first non-zero dose
-  int idx = find_first_nonzero(doses);
-  prv_dose = doses[idx];
+  // set prv_dose to first dose, if at t=0
+  if(as<NumericVector>(par["nominal_dose_times"])[0] == 0) {
+    prv_dose = as<NumericVector>(par["dose_amts"])[0];
+  }
   t_prv_dose = times[0];
 
   // Main call to ODE solver, initialize any variables in ode code

--- a/inst/cpp/sim.cpp
+++ b/inst/cpp/sim.cpp
@@ -50,6 +50,18 @@ void pk_code (int i, std::vector<double> times, std::vector<double> doses, doubl
   // insert custom pk event code
 }
 
+int find_first_nonzero(std::vector<double> vect) {
+  // find first nonzero value in vector, returns first value if non found
+  int index = 0;
+  for(int i = 0; i < vect.size(); i++) {
+    if(vect[i] > 0) {
+      index = i;
+      break;
+    }
+  }
+  return(index);
+}
+
 // [[Rcpp::export]]
 List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_bins, double step_size) {
   std::vector<double> t;
@@ -71,7 +83,6 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
   int start;
   memset(rate, 0, sizeof(rate));
   // insert observation compartment
-  // insert bioavailability definition
   // insert covariate definitions
   // insert_parameter_definitions
 
@@ -81,7 +92,10 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
   // call ode() once to pre-calculate any initial variables
   // insert A dAdt state_init
   set_covariates(0);
-  prv_dose = doses[0];
+
+  // set prv_dose to first non-zero dose
+  int idx = find_first_nonzero(doses);
+  prv_dose = doses[idx];
   t_prv_dose = times[0];
 
   // Main call to ODE solver, initialize any variables in ode code


### PR DESCRIPTION
A model where F (bioav) was defined in ODE block as:

```
    F1_avg = F1 * pow(prv_dose/1000.0, -0.15) ;\
    F1i = F1_avg * exp(kappa_F1) ;\
```
resulted in NAs in the simulated concentrations. The code however runs fine when used in PK code.

This was because in the internal C++ code, the first row is not actually a dosing event, but an initalization row that does not have a dose. However, `prv_dose` is initialized as: `prv_dose = doses[0];`, which then results in `prv_dose` being zero. Then in the above definition a value of `prv_dose=0` will results in `Inf` for `F1_avg`.

We can avoid this by instead just reading the first non-zero value in the dose column of the event table and initializing `prv_dose` with that.

This change shouldn't affect anything else.

