### PR TITLE
fix handling of dose-dependent parameters

### DIFF
--- a/PKPDsim.Rproj
+++ b/PKPDsim.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ae147ab9-a513-4f38-a09b-ceb5d569c3a0
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/inst/cpp/sim.cpp
+++ b/inst/cpp/sim.cpp
@@ -42,6 +42,19 @@ ode_out sim_cpp (const NumericVector Ainit, double t_start, double t_end, double
   return(tmp);
 }
 
+int first_dose_index(std::vector<double> time, std::vector<int> evid) {
+  // find row index for first dose (evid=1, doesn't have to be first event row)
+  // returns 0 if no dose given at all
+  int index = 0;
+  for(int i = 0; i < time.size(); i++) {
+    if(evid[i] == 1) {
+      index = i;
+      break;
+    }
+  }
+  return(index);
+}
+
 void set_covariates(int i) {
   // insert covariates for integration period
 }
@@ -76,12 +89,13 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
   // insert_parameter_definitions
 
   // Initialize parameters, compartments, etc:
+  int idx = first_dose_index(times, evid);
+  prv_dose = doses[idx];
+  pk_code(0, times, doses, prv_dose, dose_cmt, dose_type, iov_bin);
 
-  pk_code(0, times, doses, doses[0], dose_cmt, dose_type, iov_bin);
   // call ode() once to pre-calculate any initial variables
   // insert A dAdt state_init
   set_covariates(0);
-  prv_dose = doses[0];
   t_prv_dose = times[0];
 
   // Main call to ODE solver, initialize any variables in ode code


### PR DESCRIPTION
In the core `sim()` function there was an edge case where dose-dependent variables or parameters were not correctly initialized, being either NA or a wrong value. Dose-dependent variables are usually implemented using the built-in `prv_dose` variable that updates whenever a new dose is given. For the first initialization step (before looping through the event record), this was previously getting set to the first value in the `dose` column of the event record. But the first row of the event record is never a dosing record, but an initialization row to make sure variables are correctly set, so it will never hold the value of the dose. Therefore the `prv_dose` value upon initialization was always set to 0.

This fix improves that by finding the first dose record (evid == 1) in the event record, and using that value to initalize.

Technically it would be slightly better to use the first dose record only if the dose is at t=0 because the user may expect that `prv_dose` stays 0 until a dose is given, but that is currently not possible due to the way lag-time is implemented. That will be addressed in a later PR.

See also [this closed PR](https://github.com/InsightRX/PKPDsim/pull/111) for more details / thoughts, and description of another minor issue with current lagtime implementation.