### PR TITLE
RXR-2577 fix memory access issue 

### DIFF
--- a/PKPDsim.Rproj
+++ b/PKPDsim.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: ae147ab9-a513-4f38-a09b-ceb5d569c3a0
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/R/sim.R
+++ b/R/sim.R
@@ -180,6 +180,7 @@ sim <- function (ode = NULL,
     } else {
       cpp <- FALSE
     }
+
     ## Add _kappa parameters (IOV) if not specified by user but required by model
     if(!is.null(attr(ode, "parameters"))) {
       p_mod <- attr(ode, "parameters")
@@ -192,6 +193,10 @@ sim <- function (ode = NULL,
         }
         p <- parameters
       }
+    }
+    ## Throw warning when iov_bins supplied but no IOV in model, and reset iov_bins
+    if(!is.null(iov_bins) && !is.null(attr(ode, "iov")$n_bins) && attr(ode, "iov")$n_bins == 1) {
+      stop("No IOV implemented for this model, please set `iov_bins` argument to `NULL`.")
     }
     if(!is.null(attr(ode, "iov")$n_bins) && attr(ode, "iov")$n_bins > 1) {
       if(attr(ode, "iov")$n_bins < (length(iov_bins)-1)) {


### PR DESCRIPTION
This occurs when specifying IOV bins when not implemented. It will throw a low-level warning, but after that it will also cause a memory access failure that causes R to abort the session.

This PR should fix this, added a test for it as well that failed previously. I've chosen to make this an error and not a warning since this is important to get right, so IMO better than e.g. throwing a soft warning and ignoring the `iov_bins` argument.