### PR TITLE
RXR-2593: Ensure covariate times are correct when t_init is non-zero

### DIFF
--- a/R/sim.R
+++ b/R/sim.R
@@ -355,7 +355,7 @@ sim <- function (ode = NULL,
       if(is.null(covariates_table)) {
         design <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init, p, covariates, model = ode, obs_type = obs_type)
       } else {
-        design <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init, p, covariates[[1]], model = ode, obs_type = obs_type)
+        design <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init, p, covariates_table[[1]], model = ode, obs_type = obs_type)
       }
       if(return_event_table) {
         return(design)

--- a/R/sim.R
+++ b/R/sim.R
@@ -160,7 +160,20 @@ sim <- function (ode = NULL,
       attr(ode, "cmt_mapping")
     )
   }
-  if(t_init != 0) regimen$dose_times <- regimen$dose_times + t_init
+  if(t_init != 0) {
+    regimen$dose_times <- regimen$dose_times + t_init
+    if (!is.null(covariates)) {
+      for (key in names(covariates)) {
+        covariates[[key]] <- new_covariate(
+          value = covariates[[key]]$value,
+          times = covariates[[key]]$times + t_init,
+          implementation = covariates[[key]]$implementation
+        )
+      }
+    } else if (!is.null(covariates_table)) {
+      covariates_table$t <- covariates_table$t + t_init
+    }
+  }
   p <- as.list(parameters)
   if(!is.null(t_obs)) {
     t_obs <- round(t_obs, 6)


### PR DESCRIPTION
We allow the argument t_init to be specified in the case of observations prior to the first dose. When this occurs, we shift the regimen start time to begin at t_init, effectively changing the "origin". However, we were not also shifting covariate times. As a result, there could be a mismatch in covariate times and dose times in simulation.

I opted to call PKPDsim::new_covariate again to update the covariate times since this ensures the covariate values are correctly extrapolated backwards to t = 0, respecting existing implementation method for extrapolation.

