### PR TITLE
RXR-2789: also adjust covariate times to account for prepended steady-state dosing

### DIFF
--- a/R/create_event_table.R
+++ b/R/create_event_table.R
@@ -196,7 +196,10 @@ create_event_table <- function(
       t_tte <- t_tte + t_init
       if(is.null(t_tte) || is.na(t_max) || t_max < max(t_tte)) { t_max <- max(t_tte) }
     }
+  } else if (!is.null(t_obs)) {
+    t_max <- max(c(t_max, t_obs))
   }
+
   design <- design[design$t <= t_max,]
   design[length(design[,1])+1,] <- utils::tail(design,1)
   design[length(design[,1]), c("t", "dose")] <- c(t_max,0)

--- a/R/sim.R
+++ b/R/sim.R
@@ -429,7 +429,7 @@ sim <- function (ode = NULL,
     p_i <- p
     if(!is.null(covariates_table)) {
       covariates_tmp <- covariates_table[[i]]
-      design_i <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init, p_i, covariates_table[[i]], model = ode, obs_type = obs_type)
+      design_i <- create_event_table(regimen, t_max, t_obs, t_tte, t_init = t_init + t_ss, p_i, covariates_table[[i]], model = ode, obs_type = obs_type)
     } else {
       covariates_tmp <- covariates
     }
@@ -450,13 +450,13 @@ sim <- function (ode = NULL,
       if(is.null(obs_type)) {
         obs_type <- rep(1, length(t_obs))
       }
-      design_i <- create_event_table(regimen[[i]], t_max, t_obs, t_tte, t_init = t_init, p_i, covariates_tmp)
+      design_i <- create_event_table(regimen[[i]], t_max, t_obs, t_tte, t_init = t_init + t_ss, p_i, covariates_tmp)
       if(inherits(regimen, "regimen_multiple")) {
         p_i$dose_times <- regimen[[i]]$dose_times
         p_i$dose_amts <- regimen[[i]]$dose_amts
       }
     }
-    t_obs <- round(t_obs + t_init, 6) # make sure the precision is not too high, otherwise NAs will be generated when t_obs specified
+    t_obs <- round(t_obs + t_init + t_ss, 6) # make sure the precision is not too high, otherwise NAs will be generated when t_obs specified
     if (!is.null(omega)) {
       n_om <- nrow(omega_mat)
       if(length(omega_type) == 1) {

--- a/R/sim.R
+++ b/R/sim.R
@@ -129,7 +129,7 @@ sim <- function (ode = NULL,
     regimen <- join_regimen(regimen_orig$ss_regimen, regimen, interval = regimen_orig$ss_regimen$interval)
     t_ss <- max(regimen_orig$ss_regimen$dose_times) + regimen_orig$ss_regimen$interval
     if(!is.null(t_max)) t_max <- t_max + t_ss
-    ## Also adjust the times for the covariates!
+    # covariate times get adjusted below, along with t_init adjustment
   } else {
     t_ss <- 0
     regimen_orig <- regimen

--- a/R/sim.R
+++ b/R/sim.R
@@ -129,7 +129,7 @@ sim <- function (ode = NULL,
     regimen <- join_regimen(regimen_orig$ss_regimen, regimen, interval = regimen_orig$ss_regimen$interval)
     t_ss <- max(regimen_orig$ss_regimen$dose_times) + regimen_orig$ss_regimen$interval
     # covariate times get adjusted below, along with t_init adjustment
-    # t_max gets adjusted in `create_event_table`, t_obs gets adjust later
+    # t_max & t_obs are adjusted later
   } else {
     t_ss <- 0
     regimen_orig <- regimen
@@ -137,6 +137,8 @@ sim <- function (ode = NULL,
   # if we have both TDM before the first dose and steady state dosing, we want
   # to shift dosing only as much as we need to.
   t_init <- pmax(0, t_init - t_ss)
+  # adjust max simulation time based on time shifts + specified obs
+  if (!is.null(t_max)) t_max <- t_max + t_init + t_ss
   ## Add duplicate "doses" to regimen, e.g. for double-absorption compartments
   dose_dupl <- attr(ode, "dose")$duplicate
   if(!is.null(dose_dupl)) {

--- a/R/sim.R
+++ b/R/sim.R
@@ -135,7 +135,9 @@ sim <- function (ode = NULL,
     regimen_orig <- regimen
   }
   # if we have both TDM before the first dose and steady state dosing, we want
-  # to shift dosing only as much as we need to.
+  # to shift dosing only as much as we need to. Keep t_init and t_ss as separate
+  # variables, however, since we need to refer to these time shifts in different
+  # places.
   t_init <- pmax(0, t_init - t_ss)
   # adjust max simulation time based on time shifts + specified obs
   if (!is.null(t_max)) t_max <- t_max + t_init + t_ss

--- a/R/sim.R
+++ b/R/sim.R
@@ -128,7 +128,6 @@ sim <- function (ode = NULL,
     regimen_orig <- regimen
     regimen <- join_regimen(regimen_orig$ss_regimen, regimen, interval = regimen_orig$ss_regimen$interval)
     t_ss <- max(regimen_orig$ss_regimen$dose_times) + regimen_orig$ss_regimen$interval
-    t_obs <- t_obs + t_ss
     if(!is.null(t_max)) t_max <- t_max + t_ss
     ## Also adjust the times for the covariates!
   } else {
@@ -633,7 +632,7 @@ sim <- function (ode = NULL,
       ruv = res_var,
       obs_type = comb[comb$comp == 'obs',]$obs_type)
   }
-  comb$t <- comb$t - t_init - t_ss
+  comb$t <- comb$t - t_init
 
   class(comb) <- c("PKPDsim_data", class(comb))
   attr(comb, "regimen") <- regimen_orig

--- a/tests/testthat/test_sim.R
+++ b/tests/testthat/test_sim.R
@@ -21,18 +21,18 @@ test_that("return_event_table=TRUE returns an appropriate event table", {
   expect_equal(
     evtab1,
     structure(list(
-      t = c(0, 2, 2, 12, 14, 24, 26, 48, 48), 
-      dose = c(100, 0, 0, 100, 0, 100, 0, 0, 0), 
-      type = c(1, 0, 1, 1, 1, 1, 1, 0, 0), 
-      dum = c(0, 0, 1, 0, 1, 0, 1, 0, 0), 
-      dose_cmt = c(1, 0, 1, 1, 1, 1, 1, 0, 0), 
-      t_inf = c(2, 0, 0, 2, 0, 2, 0, 0, 0), 
-      evid = c(1, 0, 2, 1, 2, 1, 2, 0, 0), 
-      bioav = c(1, 0, 0, 1, 0, 1, 0, 0, 0), 
-      rate = c(50, 0, -50, 50, -50, 50, -50, 0, 0), 
+      t = c(0, 2, 2, 12, 14, 24, 26, 48, 48),
+      dose = c(100, 0, 0, 100, 0, 100, 0, 0, 0),
+      type = c(1, 0, 1, 1, 1, 1, 1, 0, 0),
+      dum = c(0, 0, 1, 0, 1, 0, 1, 0, 0),
+      dose_cmt = c(1, 0, 1, 1, 1, 1, 1, 0, 0),
+      t_inf = c(2, 0, 0, 2, 0, 2, 0, 0, 0),
+      evid = c(1, 0, 2, 1, 2, 1, 2, 0, 0),
+      bioav = c(1, 0, 0, 1, 0, 1, 0, 0, 0),
+      rate = c(50, 0, -50, 50, -50, 50, -50, 0, 0),
       obs_type = c(0, 1, 1, 0, 0, 0, 0, 1, 1)
-    ), 
-    row.names = c(1L, 3L, 2L, 4L, 5L, 6L, 7L, 8L, 9L), 
+    ),
+    row.names = c(1L, 3L, 2L, 4L, 5L, 6L, 7L, 8L, 9L),
     class = "data.frame"
   ))
 })
@@ -50,24 +50,24 @@ test_that("return_event_table=TRUE returns an appropriate event table with covar
   expect_equal(
     evtab2,
     structure(list(
-      t = c(0, 0, 2, 2, 12, 14, 24, 24, 26, 48), 
-      dose = c(0, 100, 0, 0, 100, 0, 0, 100, 0, 0), 
-      type = c(0, 1, 0, 1, 1, 1, 0, 1, 1, 0), 
-      dum = c(0, 0, 0, 1, 0, 1, 0, 0, 1, 0), 
-      dose_cmt = c(0, 1, 0, 1, 1, 1, 0, 1, 1, 0), 
-      t_inf = c(0, 2, 0, 0, 2, 0, 0, 2, 0, 0), 
-      evid = c(2, 1, 0, 2, 1, 2, 2, 1, 2, 0), 
-      bioav = c(1, 1, 0, 0, 1, 0, 1, 1, 0, 0), 
-      rate = c(0, 50, 0, -50, 50, -50, 0, 50, -50, 0), 
-      cov_CRCL = c(70, 70, 70, 70, 70, 70, 80, 80, 80, 80), 
-      cov_t_CRCL = c(0, 0, 0, 0, 0, 0, 24, 24, 24, 24), 
-      gradients_CRCL = c(0.416666666666667, 0.416666666666667, 0.416666666666667, 0.416666666666667, 0.416666666666667, 0.416666666666667, 0, 0, 0, 0), 
-      cov_WT = c(70, 70, 70, 70, 70, 70, 70, 70, 70, 70), 
-      cov_t_WT = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 
-      gradients_WT = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 
+      t = c(0, 0, 2, 2, 12, 14, 24, 24, 26, 48),
+      dose = c(0, 100, 0, 0, 100, 0, 0, 100, 0, 0),
+      type = c(0, 1, 0, 1, 1, 1, 0, 1, 1, 0),
+      dum = c(0, 0, 0, 1, 0, 1, 0, 0, 1, 0),
+      dose_cmt = c(0, 1, 0, 1, 1, 1, 0, 1, 1, 0),
+      t_inf = c(0, 2, 0, 0, 2, 0, 0, 2, 0, 0),
+      evid = c(2, 1, 0, 2, 1, 2, 2, 1, 2, 0),
+      bioav = c(1, 1, 0, 0, 1, 0, 1, 1, 0, 0),
+      rate = c(0, 50, 0, -50, 50, -50, 0, 50, -50, 0),
+      cov_CRCL = c(70, 70, 70, 70, 70, 70, 80, 80, 80, 80),
+      cov_t_CRCL = c(0, 0, 0, 0, 0, 0, 24, 24, 24, 24),
+      gradients_CRCL = c(0.416666666666667, 0.416666666666667, 0.416666666666667, 0.416666666666667, 0.416666666666667, 0.416666666666667, 0, 0, 0, 0),
+      cov_WT = c(70, 70, 70, 70, 70, 70, 70, 70, 70, 70),
+      cov_t_WT = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      gradients_WT = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
       obs_type = c(0, 0, 1, 1, 0, 0, 0, 0, 0, 1)
-    ), 
-    row.names = c(2L, 1L, 4L, 3L, 5L, 6L, 8L, 7L, 9L, 10L), 
+    ),
+    row.names = c(2L, 1L, 4L, 3L, 5L, 6L, 8L, 7L, 9L, 10L),
     class = "data.frame"
   ))
 })
@@ -219,3 +219,240 @@ test_that("covariates_table and doses are shifted correctly when t_init != 0", {
   expect_equal(first_dose, evtab1[which(evtab1$dose > 0)[1], ])
 })
 
+
+test_that("covariates are shifted correctly when t_ss != 0", {
+  covs <- list(
+    SCR = new_covariate(
+      value = c(0.5, 0.9),
+      times = c(3, 30),
+      implementation = "interpolate"
+    ),
+    CRRT = new_covariate(
+      value = c(0, 1),
+      times = c(0, 30),
+      implementation = "locf"
+    )
+  )
+
+  reg <- new_regimen(
+    amt = 1000, interval = 12, n = 6, t_inf = 1, type = "infusion",
+    ss = TRUE
+  )
+  t_ss <- max(reg$ss_regimen$dose_times) + reg$interval # 120
+
+  # use return_event_table = TRUE since we can just check that the event table
+  # is correct, we don't need to simulate the whole ODE
+  attr( mod_1cmt_iv, "covariates") <- "SCR" # req'd to add cov to event table
+  evtab1 <- suppressMessages(sim(
+    mod_1cmt_iv,
+    parameters = par,
+    covariates = covs,
+    regimen = reg,
+    t_obs = t_obs,
+    t_init = 0,
+    return_event_table = TRUE
+  ))
+
+  # the first observation should be the same as the initial available
+  # observations, with no gradient:
+  row1 <- evtab1[1,]
+  expect_equal(row1$cov_SCR, covs$SCR$value[1])
+  expect_equal(row1$gradients_SCR, 0)
+
+  # the event table should have a row for covariate changes at t = 3 + 120
+  SCR_change <- evtab1[which(evtab1$gradients_SCR > 0)[1], ]
+  expect_equal(SCR_change$t, 3 + t_ss)
+  expect_equal(SCR_change$evid, 2)
+
+  # the first dose value should be at t = 0
+  first_dose <- evtab1[which(evtab1$evid == 1)[1], ]
+  expect_equal(first_dose$t, 0)
+  expect_equal(first_dose, evtab1[which(evtab1$dose > 0)[1], ])
+})
+
+test_that("covariates_table is shifted correctly when steady state reg", {
+  cov_table <- data.frame(
+    id = c(1, 1),
+    SCR = c(50, 150),
+    t = c(3, 13)
+  )
+  reg <- new_regimen(
+    amt = 1000, interval = 12, n = 6, t_inf = 1, type = "infusion",
+    ss = TRUE
+  )
+  t_ss <- max(reg$ss_regimen$dose_times) + reg$interval
+
+  # use return_event_table = TRUE since we can just check that the event table
+  # is correct, we don't need to simulate the whole ODE
+  attr( mod_1cmt_iv, "covariates") <- "SCR" # req'd to add cov to event table
+  evtab1 <- suppressMessages(sim_ode(
+    mod_1cmt_iv,
+    parameters = par,
+    covariates_table = cov_table,
+    regimen = reg,
+    t_obs = t_obs,
+    t_init = 0,
+    return_event_table = TRUE
+  ))
+
+  # the first observation should be the same as the initial available
+  # observations, with no gradient:
+  row1 <- evtab1[1,]
+  expect_equal(row1$cov_SCR, cov_table$SCR[1])
+  expect_equal(row1$gradients_SCR, 0)
+
+  # the event table should have a row for covariate changes at t = 3 + 120
+  SCR_change <- evtab1[which(evtab1$gradients_SCR > 0)[1], ]
+  expect_equal(SCR_change$t, 3 + t_ss)
+  expect_equal(SCR_change$evid, 2)
+
+  # the first dose value should be at t = 0
+  first_dose <- evtab1[which(evtab1$evid == 1)[1], ]
+  expect_equal(first_dose$t, 0)
+  expect_equal(first_dose, evtab1[which(evtab1$dose > 0)[1], ])
+})
+
+test_that("covariates are shifted correctly when t_ss != 0 & t_init != 0", {
+  covs <- list(
+    SCR = new_covariate(
+      value = c(0.5, 0.9),
+      times = c(3, 30),
+      implementation = "interpolate"
+    ),
+    CRRT = new_covariate(
+      value = c(0, 1),
+      times = c(0, 30),
+      implementation = "locf"
+    )
+  )
+
+  reg <- new_regimen(
+    amt = 1000, interval = 12, n = 6, t_inf = 1, type = "infusion",
+    ss = TRUE
+  )
+  t_ss <- max(reg$ss_regimen$dose_times) + reg$interval # 120
+
+  # use return_event_table = TRUE since we can just check that the event table
+  # is correct, we don't need to simulate the whole ODE
+  attr( mod_1cmt_iv, "covariates") <- "SCR" # req'd to add cov to event table
+  evtab1 <- suppressMessages(sim(
+    mod_1cmt_iv,
+    parameters = par,
+    covariates = covs,
+    regimen = reg,
+    t_obs = t_obs,
+    t_init = 7,
+    return_event_table = TRUE
+  ))
+
+  # the first observation should be the same as the initial available
+  # observations, with no gradient:
+  row1 <- evtab1[1,]
+  expect_equal(row1$cov_SCR, covs$SCR$value[1])
+  expect_equal(row1$gradients_SCR, 0)
+
+  # the event table should have a row for covariate changes at t = 3 + 120
+  SCR_change <- evtab1[which(evtab1$gradients_SCR > 0)[1], ]
+  expect_equal(SCR_change$t, 3 + t_ss)
+  expect_equal(SCR_change$evid, 2)
+
+  # the first dose value should be at t = 0
+  first_dose <- evtab1[which(evtab1$evid == 1)[1], ]
+  expect_equal(first_dose$t, 0)
+  expect_equal(first_dose, evtab1[which(evtab1$dose > 0)[1], ])
+
+  # now try where t_init is very long ago, i.e., before start of ss (rare)
+  evtab2 <- suppressMessages(sim(
+    mod_1cmt_iv,
+    parameters = par,
+    covariates = covs,
+    regimen = reg,
+    t_obs = t_obs,
+    t_init = 140,
+    return_event_table = TRUE
+  ))
+
+  # the first observation should be the same as the initial available
+  # observations, with no gradient:
+  row1 <- evtab2[1,]
+  expect_equal(row1$cov_SCR, covs$SCR$value[1])
+  expect_equal(row1$gradients_SCR, 0)
+
+  # the event table should have a row for covariate changes at t = 3 + 140
+  SCR_change <- evtab2[which(evtab2$gradients_SCR > 0)[1], ]
+  expect_equal(SCR_change$t, 3 + 140)
+  expect_equal(SCR_change$evid, 2)
+
+  # the first dose value should be at t = 140 - t_ss
+  first_dose <- evtab2[which(evtab2$evid == 1)[1], ]
+  expect_equal(first_dose$t, 140 - t_ss)
+  expect_equal(first_dose, evtab2[which(evtab2$dose > 0)[1], ])
+})
+
+test_that("covariates_table shifted correctly when steady state reg + t_init", {
+  cov_table <- data.frame(
+    id = c(1, 1),
+    SCR = c(50, 150),
+    t = c(3, 13)
+  )
+  reg <- new_regimen(
+    amt = 1000, interval = 12, n = 6, t_inf = 1, type = "infusion",
+    ss = TRUE
+  )
+  t_ss <- max(reg$ss_regimen$dose_times) + reg$interval
+
+  # use return_event_table = TRUE since we can just check that the event table
+  # is correct, we don't need to simulate the whole ODE
+  attr( mod_1cmt_iv, "covariates") <- "SCR" # req'd to add cov to event table
+  evtab1 <- suppressMessages(sim_ode(
+    mod_1cmt_iv,
+    parameters = par,
+    covariates_table = cov_table,
+    regimen = reg,
+    t_obs = t_obs,
+    t_init = 7,
+    return_event_table = TRUE
+  ))
+
+  # the first observation should be the same as the initial available
+  # observations, with no gradient:
+  row1 <- evtab1[1,]
+  expect_equal(row1$cov_SCR, cov_table$SCR[1])
+  expect_equal(row1$gradients_SCR, 0)
+
+  # the event table should have a row for covariate changes at t = 3 + 120
+  SCR_change <- evtab1[which(evtab1$gradients_SCR > 0)[1], ]
+  expect_equal(SCR_change$t, 3 + t_ss)
+  expect_equal(SCR_change$evid, 2)
+
+  # the first dose value should be at t = 0
+  first_dose <- evtab1[which(evtab1$evid == 1)[1], ]
+  expect_equal(first_dose$t, 0)
+  expect_equal(first_dose, evtab1[which(evtab1$dose > 0)[1], ])
+
+  # now for t_init > t_ss
+  evtab2 <- suppressMessages(sim_ode(
+    mod_1cmt_iv,
+    parameters = par,
+    covariates_table = cov_table,
+    regimen = reg,
+    t_obs = t_obs,
+    t_init = 140,
+    return_event_table = TRUE
+  ))
+  # the first observation should be the same as the initial available
+  # observations, with no gradient:
+  row1 <- evtab2[1,]
+  expect_equal(row1$cov_SCR, cov_table$SCR[1])
+  expect_equal(row1$gradients_SCR, 0)
+
+  # the event table should have a row for covariate changes at t = 3 + 140
+  SCR_change <- evtab2[which(evtab2$gradients_SCR > 0)[1], ]
+  expect_equal(SCR_change$t, 3 + 140)
+  expect_equal(SCR_change$evid, 2)
+
+  # the first dose value should be at t = 140 - t_ss
+  first_dose <- evtab2[which(evtab2$evid == 1)[1], ]
+  expect_equal(first_dose$t, 140 - t_ss)
+  expect_equal(first_dose, evtab2[which(evtab2$dose > 0)[1], ])
+})


### PR DESCRIPTION
This PR ensures we correctly adjust t_obs and covariate times for both t_init and t_ss. Previously, we were only adjusting for t_init.

I made more lines of code changes than strictly necessary so that it is easier to track which time-containing variables are adjusted when. We had been inconsistently adding t_init and t_ss, and now we should generally be adjusting for one or both at the same time, as appropriate.

I opted to keep t_init and t_ss as separate variables rather than lumping them together as one variable (e.g., t_rezero or something) because it allows for better partitioning of the sources of time adjustments. we do handle them separately in a couple places.

I added some comments throughout to clarify locations that I found confusing. I also added quite a few unit tests for various combos of t_ss and t_init and covariates/covariates_table
