### PR TITLE
RXR-3049: small bug when interval = infusion length

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports: Rcpp (>= 1.0.13), BH, data.table, stringr, MASS,
 Suggests: 
     httr,
     testthat (>= 3.0.0),
-    mockery,
     knitr,
     rmarkdown
 LinkingTo: BH, Rcpp (>= 1.0.13)

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
     
-RUN Rscript -e "install.packages(c('mockery', 'nlmixr2', 'knitr', 'rmarkdown'), repos = 'https://cloud.r-project.org')"
+RUN Rscript -e "install.packages(c('nlmixr2', 'knitr', 'rmarkdown'), repos = 'https://cloud.r-project.org')"
 
 RUN R CMD check PKPDsim
 

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -9,4 +9,4 @@ WORKDIR /src/PKPDsim
 # Install system and CRAN dependencies
 RUN apt-get update
 RUN apt install -y pandoc qpdf
-RUN Rscript -e "install.packages(c('mockery', 'nlmixr2', 'knitr', 'rmarkdown'), repos = '${RSPM_SNAPSHOT}')"
+RUN Rscript -e "install.packages(c('nlmixr2', 'knitr', 'rmarkdown'), repos = '${RSPM_SNAPSHOT}')"

--- a/R/advan_process_infusion_doses.R
+++ b/R/advan_process_infusion_doses.R
@@ -24,7 +24,7 @@ advan_process_infusion_doses <- function (data) {
   doserowslast[, badcols] <- NA
 
   # Are there any doserows without a DV value?  These need to precede the infusion change
-  # Exclude only observation-only times (AMT==0); infusion ends coinciding with dose times
+  # Solely exclude observation-only times (AMT==0): infusion end times coinciding with dose times
   # still need an AMT=0 sentinel row so ordering is correct in the RATEALL loop.
   noDVindex <- which(!doserowslast$TIME %in% data$TIME[data$AMT == 0])
   doserowslastnoDV <- doserowslast[noDVindex,]

--- a/R/advan_process_infusion_doses.R
+++ b/R/advan_process_infusion_doses.R
@@ -26,9 +26,11 @@ advan_process_infusion_doses <- function (data) {
   # Are there any doserows without a DV value?  These need to precede the infusion change
   noDVindex <- which(!doserowslast$TIME %in% data$TIME)
   doserowslastnoDV <- doserowslast[noDVindex,]
-  doserowslastnoDV$AMT <- 0
-  doserowslastnoDV$RATE <- 0
-  doserowslastnoDV$DNUM <- NA
+  if (nrow(doserowslastnoDV) > 0) {
+    doserowslastnoDV$AMT <- 0
+    doserowslastnoDV$RATE <- 0
+    doserowslastnoDV$DNUM <- NA
+  }
 
   # Collect the new rows
   doserows <- rbind(doserows, doserowslast, doserowslastnoDV)

--- a/R/advan_process_infusion_doses.R
+++ b/R/advan_process_infusion_doses.R
@@ -24,7 +24,9 @@ advan_process_infusion_doses <- function (data) {
   doserowslast[, badcols] <- NA
 
   # Are there any doserows without a DV value?  These need to precede the infusion change
-  noDVindex <- which(!doserowslast$TIME %in% data$TIME)
+  # Exclude only observation-only times (AMT==0); infusion ends coinciding with dose times
+  # still need an AMT=0 sentinel row so ordering is correct in the RATEALL loop.
+  noDVindex <- which(!doserowslast$TIME %in% data$TIME[data$AMT == 0])
   doserowslastnoDV <- doserowslast[noDVindex,]
   if (nrow(doserowslastnoDV) > 0) {
     doserowslastnoDV$AMT <- 0

--- a/tests/testthat/test_calc_auc_analytic.R
+++ b/tests/testthat/test_calc_auc_analytic.R
@@ -113,6 +113,25 @@ test_that("Works for 1cmt model", {
   expect_equal(tmp$auc, aucfr$auc)
 })
 
+test_that("Doesn't crash when t_inf equals interval (all infusion-end times coincide with existing data times)", {
+  # Regression test: when t_inf = interval, every infusion-end event lands on the
+  # next dose's onset time (already in data$TIME). If an observation also covers
+  # the final end time, noDVindex is empty in advan_process_infusion_doses and
+  # the $<- assignment on a 0-row data frame used to throw
+  # "replacement has 1 row, data has 0".
+  reg <- new_regimen(amt = 750, n = 12, interval = 8, t_inf = 8, type = "infusion")
+  expect_no_error(
+    res <- calc_auc_analytic(
+      f = "2cmt_iv_infusion",
+      parameters = list(CL = 4.5, V = 45, Q = 2.3, V2 = 49),
+      regimen = reg,
+      t_obs = c(0, 88, 96)
+    )
+  )
+  # Trough at t=96 should be positive and finite
+  expect_true(is.finite(tail(res$y, 1)) && tail(res$y, 1) > 0)
+})
+
 test_that("Doesn't fail when t_inf is specified as 0 in regimen or as t_inf. Should be nearly equal to bolus", {
   reg1 <- new_regimen(amt = 1500, n = 10, interval = 24, type = "infusion", t_inf = 0)
   reg2 <- new_regimen(amt = 1500, n = 10, interval = 24, type = "bolus")

--- a/tests/testthat/test_calc_auc_analytic.R
+++ b/tests/testthat/test_calc_auc_analytic.R
@@ -113,23 +113,34 @@ test_that("Works for 1cmt model", {
   expect_equal(tmp$auc, aucfr$auc)
 })
 
-test_that("Doesn't crash when t_inf equals interval (all infusion-end times coincide with existing data times)", {
-  # Regression test: when t_inf = interval, every infusion-end event lands on the
-  # next dose's onset time (already in data$TIME). If an observation also covers
-  # the final end time, noDVindex is empty in advan_process_infusion_doses and
-  # the $<- assignment on a 0-row data frame used to throw
-  # "replacement has 1 row, data has 0".
-  reg <- new_regimen(amt = 750, n = 12, interval = 8, t_inf = 8, type = "infusion")
+test_that("Correct output when t_inf equals interval", {
+  # confirm that continuous infusion and infusion that is _nearly_ continuous
+  # produce nearly the same estimates and don't raise an error
+  reg_c <- new_regimen(
+    amt = 750, n = 12, interval = 8, t_inf = 8, type = "infusion"
+  )
+  reg_i <- new_regimen(
+    amt = 750, n = 12, interval = 8, t_inf = 7.999, type = "infusion"
+  )
   expect_no_error(
-    res <- calc_auc_analytic(
+    res_c <- calc_auc_analytic(
       f = "2cmt_iv_infusion",
       parameters = list(CL = 4.5, V = 45, Q = 2.3, V2 = 49),
-      regimen = reg,
+      regimen = reg_c,
       t_obs = c(0, 88, 96)
     )
   )
+  res_i <- calc_auc_analytic(
+    f = "2cmt_iv_infusion",
+    parameters = list(CL = 4.5, V = 45, Q = 2.3, V2 = 49),
+    regimen = reg_i,
+    t_obs = c(0, 88, 96)
+  )
   # Trough at t=96 should be positive and finite
-  expect_true(is.finite(tail(res$y, 1)) && tail(res$y, 1) > 0)
+  expect_true(is.finite(tail(res_c$y, 1)) && tail(res_c$y, 1) > 0)
+  # AUC and trough are nearly identical (difference is due to delta in t_inf)
+  expect_equal(round(res_c$auc[3]/res_i$auc[3], 5), 1)
+  expect_equal(round(res_c$y[3]/res_i$y[3], 3), 1)
 })
 
 test_that("Doesn't fail when t_inf is specified as 0 in regimen or as t_inf. Should be nearly equal to bolus", {

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -1,8 +1,7 @@
 test_that("now_utc returns time in UTC", {
-  mockery::stub(
-    now_utc,
-    "Sys.time",
-    structure(1640042187.11864, class = c("POSIXct", "POSIXt"))
+  local_mocked_bindings(
+    Sys.time = function() structure(1640042187.11864, class = c("POSIXct", "POSIXt")),
+    .package = "PKPDsim"
   )
   now <- now_utc()
   expect_equal(attr(now, "tzone"), "UTC")

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -1,8 +1,4 @@
 test_that("now_utc returns time in UTC", {
-  local_mocked_bindings(
-    Sys.time = function() structure(1640042187.11864, class = c("POSIXct", "POSIXt")),
-    .package = "PKPDsim"
-  )
   now <- now_utc()
   expect_equal(attr(now, "tzone"), "UTC")
 })


### PR DESCRIPTION
Fixes a bug where we tried to assign values to a row of length 0, in some cases (interval = infusion length); also removes mockery from tests (deprecated package)