### PR TITLE
RXR-3174: safety check to ensure max sim time is reasonable

### DIFF
--- a/inst/cpp/sim.cpp
+++ b/inst/cpp/sim.cpp
@@ -162,6 +162,11 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
   std::vector<int> dose_cmt, dose_type, evid, obs_type, y_type;
   // insert variable definitions
 
+  // Capture t_max from the original design before lagtime shifts any events.
+  // This is the true simulation ceiling: no output is needed beyond this point.
+  std::vector<double> orig_times = as<std::vector<double> >(design["t"]);
+  double t_max_design = *std::max_element(orig_times.begin(), orig_times.end());
+
   // Handle lagtime parameter - can be numeric or character
   NumericVector lagtime_numeric = lagtime_to_numeric(lagtime, par);
   List events = apply_lagtime(design, lagtime_numeric, n_comp);
@@ -232,6 +237,9 @@ List sim_wrapper_cpp (NumericVector A, List design, List par, NumericVector iov_
         start = 0;
       }
     }
+    // Don't integrate past the original t_max; avoid unnecessarily large vectors
+    if(t_start > t_max_design) break;
+    t_end = std::min(t_end, t_max_design);
     ode_out tmp = sim_cpp(Aupd, t_start, t_end, step_size);
     if(start == 0) { // make sure observation variables are stored
       int k = 0;

--- a/tests/testthat/test_sim.R
+++ b/tests/testthat/test_sim.R
@@ -1570,3 +1570,35 @@ describe("Timevarying covariates are handled properly", {
   })
 
 })
+
+
+test_that("sim does not exhaust memory when lagtime exceeds the simulation window", {
+  # During MAP estimation, BFGS can take an unconstrained step that pushes a
+  # lagtime parameter (e.g. TLAG) to an extreme value. apply_lagtime() shifts 
+  # every dose event forward by TLAG, placing them far beyond the observation
+  # window. This test ensures we don't simulate unnecessarily large vectors,
+  # no matter what TLAG is.
+
+  reg <- new_regimen(amt = 100, n = 3, interval = 12, type = "oral")
+  par_extreme <- list(CL = 5, V = 50, KA = 0.5, TLAG = 1e7)  # extreme TLAG
+  t_obs <- c(12, 24, 36)
+
+  expect_no_error(
+    result <- sim(
+      ode = mod_1cmt_oral_lagtime,
+      parameters = par_extreme,
+      regimen = reg,
+      t_obs = t_obs,
+      only_obs = TRUE,
+      checks = FALSE
+    )
+  )
+
+  # Should complete without error and return one row per t_obs
+  expect_equal(nrow(result), length(t_obs))
+
+  # With TLAG >> simulation window, no dose is absorbed — concentrations are 0
+  # (This is not really physiologically reasonable, the goal is to ensure that
+  # the code does not crash simulating out 1e7 hours due to large TLAG)
+  expect_true(all(result$y == 0))
+})


### PR DESCRIPTION
When trying different parameter estimates during MAP Bayesian optimization, it is possible to achieve a TLAG estimate that is very very large. In this case, it is possible that the vector of timepoints simulated becomes very, very large.

In theory, we shouldn't ever need to simulate past the t_obs time point.

This PR addresses the TLAG large vector issue by limiting sim time. Tests in this repo and dependencies pass.