### PR TITLE
Update logic for setting rate in model, when exporting regimen to NONMEM-style data.frame

### DIFF
--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -1,8 +1,8 @@
 #' Convert PKPDsim regimen to NONMEM table (doses only)
 #'
-#' Note: when bioavailability is used for insusions: NONMEM behaves differently from PKPDsim and Monolix, 
-#' in that rates are not automatically recomputed for infusions where bioavailabiliy also applies. 
-#' In PKPDsim/Monolix, for a bioavailability of 50%, an AMT of 100 mg and rate of 100mg/hr would be recalculated 
+#' Note: when bioavailability is used for insusions: NONMEM behaves differently from PKPDsim and Monolix,
+#' in that rates are not automatically recomputed for infusions where bioavailabiliy also applies.
+#' In PKPDsim/Monolix, for a bioavailability of 50%, an AMT of 100 mg and rate of 100mg/hr would be recalculated
 #' to 50 mg and 50 mg/hour, respectively, to keep the infusion length the same. This is not the case
 #' in NONMEM. Therefore, the easiest way to work around this is for the user to compute the rate manually
 #' in NONMEM using custom code. Therefore, we set the `RATE` column to `-1` for such infusions.
@@ -50,8 +50,13 @@ regimen_to_nm <- function(
         }
         bioav_dose[is.na(bioav_dose)] <- 1
       }
-      dat$RATE <- -1
-      message("Setting rate to be handled in NONMEM model using R parameters.")
+      ## Only set rate to model-specified if bioav != 1
+      ## For many IV models, bioav may be set explicitly to 1.
+      ## But there we just want to ignore.
+      if(! isTRUE(as.numeric(bioav[dose_cmt]) == 1)) {
+        dat$RATE <- -1
+        message("Setting rate to be handled in NONMEM model using R parameters.")
+      }
     }
   }
   if(!is.null(t_obs)) {

--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -1,6 +1,6 @@
 #' Convert PKPDsim regimen to NONMEM table (doses only)
 #'
-#' Note: when bioavailability is used for insusions: NONMEM behaves differently from PKPDsim and Monolix,
+#' Note: when bioavailability is used for infusions: NONMEM behaves differently from PKPDsim and Monolix,
 #' in that rates are not automatically recomputed for infusions where bioavailabiliy also applies.
 #' In PKPDsim/Monolix, for a bioavailability of 50%, an AMT of 100 mg and rate of 100mg/hr would be recalculated
 #' to 50 mg and 50 mg/hour, respectively, to keep the infusion length the same. This is not the case
@@ -53,7 +53,7 @@ regimen_to_nm <- function(
       ## Only set rate to model-specified if bioav != 1
       ## For many IV models, bioav may be set explicitly to 1.
       ## But there we just want to ignore.
-      if(! isTRUE(as.numeric(bioav[dose_cmt]) == 1)) {
+      if(!isTRUE(as.numeric(bioav[dose_cmt]) == 1)) {
         dat$RATE <- -1
         message("Setting rate to be handled in NONMEM model using R parameters.")
       }

--- a/tests/testthat/test_regimen_to_nm.R
+++ b/tests/testthat/test_regimen_to_nm.R
@@ -95,6 +95,34 @@ test_that("rate is calculated for any regimen with an infusion length", {
   expect_equal(c$RATE, c(-1, 0, 0, 0, -1, -1, -1, -1))
 })
 
+test_that("rate is kept (not set to -1) when bioavailability is exactly 1", {
+  a <- new_regimen(amt = 10, n = 5, interval = 12, t_inf = 1, type = "infusion")
+  expect_no_message(
+    {
+      b <- regimen_to_nm(
+        a,
+        t_obs = c(1, 2, 3),
+        bioav = 1
+      )
+    },
+    message = "Setting rate to be handled in NONMEM model"
+  )
+  expected_cols <- c(
+    "ID",
+    "TIME",
+    "CMT",
+    "DV",
+    "AMT",
+    "EVID",
+    "MDV",
+    "RATE"
+  )
+  expect_true(all(expected_cols %in% colnames(b)))
+  # bioav == 1 means no recalculation is needed, so the rate (amt / t_inf = 10)
+  # is kept for doses rather than being set to -1.
+  expect_equal(b$RATE, c(10, 0, 0, 0, 10, 10, 10, 10))
+})
+
 test_that("throws warning when bioav specified as model parameter and need to convert RATE, but not when not needed", {
   a <- new_regimen(
     amt = 10,


### PR DESCRIPTION
This fixes the behavior in the function that created NONMEM-style datasets from PKPDsim regimens. The earlier [modified behavior](https://github.com/InsightRX/PKPDsim/commit/399acbfa3cb3de158de94c471597bf6ab28b6622) was implemented to support models with infusion rates AND bioavailability specified. I believe the use-case for this was some oral models with zero-order absorption. In those cases, we need to make a small adjustment to the NONMEM model, and specify rate in the model itself, to properly account for bioavailability. However, for the majority of models (iv infusions) this is not needed. If `bioav` was set to 1 the logic shouldn't fire, and rate shouldn't have to be defined in the NONMEM model. This logic was now added.

**Note**: This PR doesn't touch any production code, it is just in a convenience function that is used in irxmodval.