### PR TITLE
Use the regimen's dosing compartments in regimen_to_nm()

### DIFF
--- a/R/regimen_to_nm.R
+++ b/R/regimen_to_nm.R
@@ -8,7 +8,8 @@
 #' in NONMEM using custom code. Therefore, we set the `RATE` column to `-1` for such infusions.
 #'
 #' @param reg `PKPDsim` regimen, created using `new_regimen()` function
-#' @param dose_cmt dosing compartment, if not specified in `reg` object
+#' @param dose_cmt dosing compartment, if not specified in `reg` object. When
+#'   supplied explicitly, takes precedence over the compartments in `reg`.
 #' @param n_ind repeat for `n_ind` subjects
 #' @param t_obs add observation time(s)
 #' @param obs_cmt observation compartment for added observation time(s)
@@ -26,6 +27,9 @@ regimen_to_nm <- function(
 ) {
   if(is.null(reg) || ! "regimen" %in% class(reg)) {
     stop("No regimen or invalid regimen object supplied.")
+  }
+  if(missing(dose_cmt) && !is.null(reg$cmt)) {
+    dose_cmt <- reg$cmt
   }
   dat <- data.frame(cbind(
     ID = rep(1:n_ind, each = length(reg$dose_times)),

--- a/man/regimen_to_nm.Rd
+++ b/man/regimen_to_nm.Rd
@@ -16,7 +16,8 @@ regimen_to_nm(
 \arguments{
 \item{reg}{\code{PKPDsim} regimen, created using \code{new_regimen()} function}
 
-\item{dose_cmt}{dosing compartment, if not specified in \code{reg} object}
+\item{dose_cmt}{dosing compartment, if not specified in \code{reg} object. When
+supplied explicitly, takes precedence over the compartments in \code{reg}.}
 
 \item{n_ind}{repeat for \code{n_ind} subjects}
 

--- a/tests/testthat/test_regimen_to_nm.R
+++ b/tests/testthat/test_regimen_to_nm.R
@@ -154,3 +154,55 @@ test_that("throws warning when bioav specified as model parameter and need to co
     "For compartments where bioavailability is specified"
   )
 })
+
+test_that("dosing compartments specified in the regimen are used for CMT", {
+  a <- new_regimen(
+    amt = c(100, 100, 150),
+    times = c(0, 12, 24),
+    type = "bolus",
+    cmt = c(2, 2, 1)
+  )
+  b <- regimen_to_nm(a)
+  expect_equal(b$CMT, c(2, 2, 1))
+})
+
+test_that("dose_cmt is used when the regimen has no dosing compartments", {
+  a <- new_regimen(amt = 10, n = 3, interval = 12)
+  expect_equal(regimen_to_nm(a)$CMT, c(1, 1, 1))
+  expect_equal(regimen_to_nm(a, dose_cmt = 2)$CMT, c(2, 2, 2))
+})
+
+test_that("explicit dose_cmt takes precedence over regimen dosing compartments", {
+  a <- new_regimen(amt = 10, times = c(0, 12), type = "bolus", cmt = c(2, 2))
+  expect_equal(regimen_to_nm(a, dose_cmt = 1)$CMT, c(1, 1))
+  expect_equal(regimen_to_nm(a, dose_cmt = c(3, 4))$CMT, c(3, 4))
+})
+
+test_that("dosing compartments survive a NONMEM round trip", {
+  pt <- data.frame(
+    ID = 1,
+    EVID = c(1, 1, 0, 1, 1, 0, 1, 1, 0),
+    CMT = c(2, 2, 2, 2, 2, 2, 1, 1, 2), # last two doses are oral
+    AMT = c(100, 100, 0, 200, 200, 0, 150, 150, 0),
+    TIME = c(0, 12, 23, 25, 36, 47, 48, 60, 71),
+    RATE = c(100, 100, 0, 200, 400, 0, 0, 0, 0),
+    DV = c(0, 0, 5, 0, 0, 12, 0, 0, 14)
+  )
+  reg <- nm_to_regimen(pt)
+  b <- regimen_to_nm(reg)
+  expect_equal(b$CMT, pt$CMT[pt$EVID == 1])
+})
+
+test_that("observations keep obs_cmt when the regimen specifies dosing compartments", {
+  a <- new_regimen(amt = 10, times = c(0, 12), type = "bolus", cmt = c(2, 2))
+  b <- regimen_to_nm(a, t_obs = c(1, 2), obs_cmt = 1)
+  expect_equal(b$CMT[b$EVID == 1], c(2, 2))
+  expect_equal(b$CMT[b$EVID == 0], c(1, 1))
+})
+
+test_that("dosing compartments are repeated for each individual", {
+  a <- new_regimen(amt = 10, times = c(0, 12), type = "bolus", cmt = c(2, 1))
+  b <- regimen_to_nm(a, n_ind = 3)
+  expect_equal(b$ID, rep(1:3, each = 2))
+  expect_equal(b$CMT, rep(c(2, 1), 3))
+})


### PR DESCRIPTION
This PR proposes using the dosing compartments already stored on a regimen when exporting it with `regimen_to_nm()`, so that a regimen read in from a NONMEM dataset comes back out with its `CMT` column intact. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/358. You can sign in with your GitHub ID to claim ownership of the project.

## What happens today

`regimen_to_nm()` documents `dose_cmt` as the "dosing compartment, if not specified in `reg` object", but the implementation never reads `reg$cmt` — it always writes the `dose_cmt` argument (default `1`) into the `CMT` column. Regimens do carry per-dose compartments: `new_regimen(cmt = ...)` stores them, and `nm_to_regimen()` fills them in from the `CMT` column of a NONMEM dataset, which `tests/testthat/test_nm_to_regimen.R` asserts directly. `create_event_table()` — the path `sim()` takes — gives `reg$cmt` top priority, above `cmt_mapping` and above the model's own dose compartment. So the same regimen simulates into one set of compartments and exports as another, with nothing printed to say so.

Reproduced on `master` at 93b8bbd, using the dataset from your own `nm_to_regimen()` test ("Doses in different compartments handled"):

```r
pt <- data.frame(
  ID   = 1,
  EVID = c(1, 1, 0, 1, 1, 0, 1, 1, 0),
  CMT  = c(2, 2, 2, 2, 2, 2, 1, 1, 2),   # last two doses are oral
  AMT  = c(100, 100, 0, 200, 200, 0, 150, 150, 0),
  TIME = c(0, 12, 23, 25, 36, 47, 48, 60, 71),
  RATE = c(100, 100, 0, 200, 400, 0, 0, 0, 0),
  DV   = c(0, 0, 5, 0, 0, 12, 0, 0, 14)
)
reg <- nm_to_regimen(pt)
reg$cmt
#> [1] 2 2 2 2 1 1
regimen_to_nm(reg)$CMT
#> [1] 1 1 1 1 1 1
```

Next to what the simulation uses for that same regimen:

```
sim() dose_cmt for the 6 doses: 2, 2, 2, 2, 1, 1
regimen_to_nm() CMT           : 1, 1, 1, 1, 1, 1
```

## The change

Three lines in `regimen_to_nm()`: when the caller has not supplied `dose_cmt`, fall back to `reg$cmt`. An explicitly supplied `dose_cmt` still takes precedence, so every existing call keeps its current output — including the ones in your own test file that pass `dose_cmt = c(1, 2, 1, 2, 2)` alongside a regimen that has no compartments of its own. The only behaviour that moves is the case that was silently exporting compartment 1. The `@param` text and the generated `.Rd` are updated to match.

## How it was verified

Six tests were added to `tests/testthat/test_regimen_to_nm.R`: per-dose compartments land in `CMT`, a NONMEM round trip preserves them, an explicit `dose_cmt` still overrides them, a regimen without compartments still gets `dose_cmt` (default and explicit), observation rows keep `obs_cmt`, and `n_ind > 1` repeats the compartments per subject. Applied to `master` without the one-line fallback, four of them fail:

```
── 1. Failure ('test_regimen_to_nm.R:166:3'): dosing compartments specified in the regimen are used for CMT
Expected `b$CMT` to equal `c(2, 2, 1)`.
  `actual`: 1.0 1.0 1.0
`expected`: 2.0 2.0 1.0
── 2. Failure ('test_regimen_to_nm.R:193:3'): dosing compartments survive a NONMEM round trip
Expected `b$CMT` to equal `pt$CMT[pt$EVID == 1]`.
  `actual`: 1.0 1.0 1.0 1.0 1.0 1.0
`expected`: 2.0 2.0 2.0 2.0 1.0 1.0
── 3. Failure ('test_regimen_to_nm.R:199:3'): observations keep obs_cmt when the regimen specifies dosing compartments
── 4. Failure ('test_regimen_to_nm.R:207:3'): dosing compartments are repeated for each individual
```

The whole suite was run both ways in `rocker/r-ver` with `NOT_CRAN=true`, so nothing was skipped:

```
before (tests only):  [ FAIL 4 | WARN 5 | SKIP 0 | PASS 680 ]
after  (with fix):    [ FAIL 0 | WARN 5 | SKIP 0 | PASS 684 ]
```

No new failures, and the same five warnings that were already there.

## How this was managed

This work was tracked as a single story on a board imported from this repository's own issues and pull requests — 140 stories in all — which you can open here:

- story: https://eastagiletracker.com/projects/358/stories/220266
- board: https://eastagiletracker.com/projects/358

![board](https://raw.githubusercontent.com/eastagiletracker/PKPDsim/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
