### PR TITLE
RXR-3256: open-source beta lactam implementations

### DIFF
--- a/inst/models/pk_cefepime_alvarez.json5
+++ b/inst/models/pk_cefepime_alvarez.json5
@@ -1,0 +1,65 @@
+{
+  "id": "pk_cefepime_alvarez",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1];\
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1];\
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    CLi = CL_comb * (TH_CL * exp(TH_CR * CR/0.47))  \
+    CLtot = CLi + CL_HEMO \
+    Vi = V \
+    Qi = Q \
+    V2i = V2 \
+  ",
+  "n_comp": 7,
+  "obs": { "variable": ["CONC"] },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CR", "MIC", "FU" , "CL_HEMO"],
+  "variables": [ "CLi", "Vi", "Qi", "V2i", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF", "CLtot" ],
+  "parameters" : {
+    "CL_comb": 1.0,
+    "V": 23.8,
+    "Q": 23.4,
+    "V2": 13.3,
+    "TH_CL": 20.6,
+    "TH_CR": -0.415
+  },
+  "fixed": [
+    "TH_CL",
+    "TH_CR"
+  ],
+  "omega_matrix": [
+    0.051529,
+    0, 0.093636,
+    0, 0, 1.0,
+    0, 0, 0, 0.881721
+  ],
+  "ruv": {
+    "prop": [0],
+    "add": [1.86]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Álvarez et al. Antibiotics 2021",
+      "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8146514/"
+    }
+  ],
+  "version": "0.1.8"
+}

--- a/inst/models/pk_cefepime_an.json5
+++ b/inst/models/pk_cefepime_an.json5
@@ -22,13 +22,14 @@
       LBW = 1.07 * WT - 0.0148 * pow(WT, 2) / pow(HT, 2) \
     } \
     LBW = max(LBW, 30.0) \
-    CRCLi = (140.0 - AGE) * LBW * pow(0.85, (1.0-SEX)) / (72.0 * CR) \
+    CRCL = (140.0 - AGE) * LBW * pow(0.85, (1.0-SEX)) / (72.0 * CR) \
     // if (CRRT > 0) { \
     //   CLr = 1.64 \
     // } else { \
-    CLr = 2.00 * (CRCLi / 54.0) \
+    CLr = 2.00 * (CRCL / 54.0) \
     // } \
-    CLtot = CLiiv * (CLr + CLnr) + CL_HEMO \
+    CLi = CLiiv * (CLr + CLnr) \
+    CLtot = CLi + CL_HEMO \
     Vi = V * (WT/90.0) \
     Qi = Q  \
     V2i = V2 \
@@ -36,13 +37,8 @@
   "n_comp": 7,
   "obs": { "cmt": 1, "variable": ["CONC"] },
   "dose": { "cmt": 1, "bioav": [1] },
-  "cmt_mapping": {
-    "infusion": 1,
-    "infusion_iiv": 1,
-    "infusion_civ": 1
-  },
   "covariates": [ "WT", "CR", "CL_HEMO", "MIC", "SEX", "AGE", "HT", "FU" ],
-  "variables": [ "Vi", "Qi", "V2i", "CRCLi", "LBW", "CLtot", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CLr", "CONC", "CONCF" ],
+  "variables": [ "CLi", "Vi", "Qi", "V2i", "CRCL", "LBW", "CLtot", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CLr", "CONC", "CONCF" ],
   "parameters" : {
     "CLiiv": 1,
     "V": 13.4,
@@ -54,11 +50,6 @@
     "Q",
     "CLnr"
   ],
-  "iiv": {
-    "CL": 0.299,
-    "V": 0.654,
-    "V2": 0.173
-  },
   "omega_matrix": [
      0.089401,
      0, 0.427716,
@@ -74,19 +65,11 @@
     "timevarying_parameter": false,
     "init_parameter": true
   },
-  "development": {
-    "n_patients": 130,
-    "n_tdms": 278,
-    "age": { "median": 65, "IQR25": 52, "IQR75": 72, "unit": "years" },
-    "weight": { "median": 90, "IQR25": 70, "IQR75": 110, "unit": "kg" },
-    "crcl": { "median": 86, "IQR25": 52, "IQR75": 126, "unit": "ml/min" },
-    "sex": { "male": 76, "female": 54 }
-  },
   "references": [
     {
       "ref": "Guohua An, et al., 2023",
       "url": "https://academic.oup.com/jac/article-abstract/78/6/1460/7127727"
     }
   ],
-  "version": "0.1.8"
+  "version": "0.1.12"
 }

--- a/inst/models/pk_cefepime_delattre.json5
+++ b/inst/models/pk_cefepime_delattre.json5
@@ -1,0 +1,64 @@
+{
+  "id": "pk_cefepime_delattre",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1];\
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1];\
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",  
+  "pk_code": "\
+    CRCLi = (CRCL * 16.66667) * (70.0/WT)\
+    CLi = CL * pow((CRCLi/100.0), TH_CRCL) * pow(WT/70.0, 0.75)\
+    CLtot = CLi + CL_HEMO\
+    Vi = V * (WT/70.0)\
+    Qi = Q * pow(WT/70.0, 0.75)\
+    V2i = V2 * (WT/70.0)\
+  ",  
+  "n_comp": 7,
+  "obs": { "variable": ["CONC"] },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRCL", "CL_HEMO", "MIC", "FU" ],
+  "variables": [ "CLi", "Vi", "Qi", "V2i", "CRCLi", "CLtot", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF" ],
+  "parameters" : {
+    "CL": 6.77,
+    "V": 17.8,
+    "Q": 11.4,
+    "V2": 12.2,
+    "TH_CRCL": 0.41
+  },
+  "fixed": [
+    "Q",
+    "TH_CRCL"
+  ],
+  "omega_matrix": [
+     0.221841,
+     0.046158, 0.153664,
+     0.05593125, 0.04655, 0.225625
+  ],
+  "ruv": {
+    "prop": [0.228],
+    "add": [0.0001]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Delattre et al. Clin Biochem 2012",
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/22503878"
+    }
+  ],
+  "version": "0.2.19"
+}

--- a/inst/models/pk_cefepime_jonckheere.json5
+++ b/inst/models/pk_cefepime_jonckheere.json5
@@ -1,0 +1,61 @@
+{
+  "id": "pk_cefepime_jonckheere",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1];\
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1];\
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+",
+  "pk_code": "\
+    CLi = (CL_R * pow(CRCL*16.6667/60.0, TH_CRCL) + CL_NR) * pow(WT/70.0, 0.75)\
+    CLtot = CLi + CL_HEMO \
+    Vi = V * (WT/70.0)\
+    V2i = V2 * (WT/70.0)\
+    Qi = Q * pow(WT/70.0, 0.75) \
+  ",
+  "n_comp": 7,
+  "obs": { "variable": ["CONC"] },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRCL", "FU", "MIC", "CL_HEMO"],
+  "variables": [ "CLi", "Vi", "V2i", "Qi", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF", "CLtot" ],
+  "parameters" : {
+    "CL_R": 2.29,
+    "V": 10.7,
+    "CL_NR": 0.795,
+    "TH_CRCL": 0.943,
+    "Q": 11.0,
+    "V2": 12.2
+  },
+  "fixed": [ "TH_CRCL", "Q", "V2" ],
+  "omega_matrix": [
+    0.060516 ,
+    0, 0.208849,
+    0, 0, 0.481636
+  ],
+  "ruv": {
+    "prop": [0.223],
+    "add": [0.001]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Jonckheere et al. Antimicrob Agents Chemother 2020",
+      "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7187597"
+    }
+  ],
+  "version": "0.1.10"
+}

--- a/inst/models/pk_cefepime_seo.json5
+++ b/inst/models/pk_cefepime_seo.json5
@@ -1,0 +1,61 @@
+{
+  "id": "pk_cefepime_seo",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1];\
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1];\
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    CLi = CL * pow(CRCL / 4.63, 0.656) \
+    CLtot = CLi + CL_HEMO \
+    Vi = V \
+    Qi = Q  \
+    V2i = V2 \
+  ",
+  "n_comp": 7,
+  "obs": { "variable": ["CONC"] },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRCL", "CL_HEMO", "MIC", "FU"],
+  "variables": [ "CLi", "Vi", "Qi", "V2i", "CLtot", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF" ],
+  "parameters" : {
+    "CL": 6.6,
+    "V": 13.3,
+    "Q": 16.5,
+    "V2": 13.0
+  },
+  "fixed": [],
+  "omega_matrix": [
+     0.113569,
+     0, 0.116281,
+     0, 0, 0.258064,
+     0, 0, 0, 0.160801
+  ],
+  "ruv": {
+    "prop": [0.0762],
+    "add": [0.0001]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Seo, H., et al. Infection & Chemotherapy. 2023",
+      "doi": "doi.org/10.3947/ic.2022.0087",
+      "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10079447/"
+    }
+  ],
+  "version": "0.1.9"
+}

--- a/inst/models/pk_meropenem_boutzoukas.json5
+++ b/inst/models/pk_meropenem_boutzoukas.json5
@@ -1,0 +1,76 @@
+{
+  "id": "pk_meropenem_boutzoukas",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC > MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF > MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    BMI = WT / pow((HT/100.0), 2.0) \
+    if(SEX == 1) {  \
+      FFM = (9270.0 * WT) / (6680.0 + 216.0 * BMI) \
+    } else { \
+      FFM = (9270.0 * WT) / (8780.0 + 244.0 * BMI) \
+    } \
+    CRCLi = ((140.0 - AGE) * WT * pow(0.85, (1.0-SEX))) / (72.0 * CR) \
+    CRCLi = std::min(CRCLi, 300.00) \
+    CLRi = CLR * (CRCLi/88.0) \
+    CLNRi = CLNR * pow(FFM/57.0, 0.75) \
+    CLi = CL * (CLRi + CLNRi) * pow(0.67, VASO) \
+    CLtot = CLi + CL_HEMO \
+    Vi = V * (WT/82.0) \
+    Qi = Q \
+    V2i = V2 * (WT/82.0) \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "CR", "WT", "HT", "AGE", "SEX", "MIC", "FU", "CL_HEMO", "VASO"],
+  "variables": [ 
+    "CLi", "Vi", "Qi", "V2i", "CLtot", "CLNRi", "CLRi",
+    "BMI", "FFM", "CRCLi",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONCF"
+  ],
+  "parameters" : {
+    "CL": 1.0,
+    "V": 24.0,
+    "V2": 7.34,
+    "Q": 4.24,
+    "CLR": 3.81,
+    "CLNR": 3.4
+  },
+  "fixed": ["Q", "CLR", "CLNR"],
+  "omega_matrix": [
+    0.1369,
+    0, 0.2401,
+    0, 0, 1.1664
+  ],
+  "ruv": {
+    "prop": [0.30],
+    "add": [0.24]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Boutzoukas, A.E., et al., (2025). Clinical Pharmacokinetics",
+      "url": "https://link.springer.com/article/10.1007/s40262-024-01465-1"
+    }
+  ],
+  "version": "0.1.1"
+}

--- a/inst/models/pk_meropenem_delattre.json5
+++ b/inst/models/pk_meropenem_delattre.json5
@@ -1,0 +1,63 @@
+{
+  "id": "pk_meropenem_delattre",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1];\
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1];\
+    CONC = A[0]/Vi\
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC)\
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+",
+  "pk_code": "\
+    CRCLi = (CRCL * 16.66667) * (70.0/WT)\
+    CLi = CL * pow((CRCLi/100.0), TH_CRCL) * pow(WT/70.0, 0.75)\
+    CLtot = CLi + CL_HEMO\
+    Vi = V * (WT/70.0)\
+    Qi = Q * pow(WT/70.0, 0.75)\
+    V2i = V2 * (WT/70.0)\
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRCL", "CL_HEMO", "MIC", "FU" ],
+  "variables": [ 
+    "CLi", "Vi", "Qi", "V2i", 
+    "CRCLi", "CLtot", "CONC", "CONCF", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC"
+  ],
+  "fixed": ["TH_CRCL", "V2", "Q"],
+  "parameters" : {
+    "CL": 9.87,
+    "V": 24.4,
+    "Q": 4.97,
+    "V2": 7.01,
+    "TH_CRCL": 0.51
+  },
+  "omega_matrix": [
+    0.194481,
+    0.059094, 0.287296
+  ],
+  "ruv": {
+    "prop": [0.371],
+    "add": [0.0001]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Delattre et al. Clin Biochem 2012",
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/22503878"
+    }
+  ],
+  "version": "0.2.16"
+}

--- a/inst/models/pk_meropenem_gijsen.json5
+++ b/inst/models/pk_meropenem_gijsen.json5
@@ -1,0 +1,65 @@
+{
+  "id": "pk_meropenem_gijsen",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC > MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF > MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    CRCLi = ((140.0 - AGE) * WT * pow(0.85, (1.0-SEX))) / (72.0 * CR) \
+    CLi = CL * pow(CRCLi/111.7, 0.64) \
+    CLtot = CLi + CL_HEMO \
+    Vi = V \
+    Qi = Q \
+    V2i = V2 \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "CR", "WT", "AGE", "SEX", "MIC", "FU", "CL_HEMO" ],
+  "variables": [ 
+    "CRCLi", "CLi", "CLtot", "Vi", "Qi", "V2i",
+    "CONC", "CONCF",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC"
+  ],
+  "parameters" : {
+    "CL": 13.7,
+    "V": 25.5,
+    "V2": 12.4,
+    "Q": 8.1
+  },
+  "fixed": [ "Q" ],
+  "omega_matrix": [
+    0.2882449,
+    0.185, 0.2813370,
+    0, 0, 0.4405336
+  ],
+  "ruv": {
+    "prop": [0.311],
+    "add": [0.147]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Gijsen, M., et al. (2022). Infection and Drug Resistance",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8754504/"
+    }
+  ],
+  "version": "0.1.1"
+}

--- a/inst/models/pk_meropenem_li.json5
+++ b/inst/models/pk_meropenem_li.json5
@@ -1,0 +1,68 @@
+{
+  "id": "pk_meropenem_li",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC = A[0]/Vi;\
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    IBWbase = 45.5 \
+    if(SEX == 1) { IBWbase = 50; } \
+    IBW = IBWbase + 0.91 * (HT - 152.4) \
+    CRCLibw = ((140.0 - AGE) * IBW * pow(0.85, (1-SEX))) / (72.0 * CR) \
+    CLi = CL * pow(CRCLibw/83.0, 0.62) * pow(AGE/35.0, -0.34) \
+    CLtot = CLi + CL_HEMO \
+    Vi = V * pow(WT/70.0, 0.99) \
+    Qi = Q \
+    V2i = V2 \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "CR", "WT", "HT", "AGE", "SEX", "MIC", "FU", "CL_HEMO"],
+  "variables": [ 
+    "CLi", "Vi", "Qi", "V2i", "IBWbase", "IBW", "CRCLibw", "CLtot",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONCF"
+  ],
+  "parameters" : {
+    "CL": 14.6,
+    "V": 10.8,
+    "Q": 18.6,
+    "V2": 12.6
+  },
+  "fixed": [],
+  "omega_matrix": [
+    0.118,
+    0, 0.143,
+    0, 0, 0.29,
+    0, 0, 0, 0.102
+  ],
+  "ruv": {
+    "prop": [0.1876],
+    "add": [0.469]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Li, C., Kuti, J. L., Nightingale, C. H., & Nicolau, D. P. (2006). Population Pharmacokinetic Analysis and Dosing Regimen Optimization of Meropenem in Adult Patients. The Journal of Clinical Pharmacology, 46(10), 1171–1178. doi:10.1177/0091270006291035",
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/16988206"
+    }
+  ],
+  "version": "0.2.18"
+}

--- a/inst/models/pk_meropenem_minichmayr.json5
+++ b/inst/models/pk_meropenem_minichmayr.json5
@@ -1,0 +1,52 @@
+{
+  "id": "pk_meropenem_minichmayr",
+  "ode_code": "\
+    dAdt[0] = -(CLtot)*A[0]; \
+    CONC = A[0]/V;\
+    CONCF = CONC * FU \
+    dAdt[1] = (CONC>MIC)\
+    dAdt[2] = (CONC > (4 * MIC)) \
+    dAdt[3] = (CONCF>MIC) \
+    dAdt[4] = (CONCF > (4 * MIC)) \
+    dAdt[5] = CONC \
+    TGTMIC = A[1] \
+    TGT4MIC = A[2] \
+    FTGTMIC = A[3] \
+    FTGT4MIC = A[4] \
+  ",
+  "pk_code": "\
+    CLi = CL * (1.0 + 0.00924 * (CRCL * 16.6666667 - 80.0));\
+    CLtot = CLi + CL_HEMO \
+    Vi = V;\
+  ",
+  "n_comp": 6,
+  "obs": { "cmt": 1, "scale": "V" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "CRCL", "MIC", "FU", "CL_HEMO" ],
+  "variables": [ "CLi","CLtot", "Vi", "TGTMIC", "TGT4MIC",  "FTGTMIC", "FTGT4MIC", "CONC", "CONCF"],
+  "parameters" : {
+    "CL": 7.71,
+    "V": 1.0
+  },
+  "omega_matrix": [
+    0.257
+  ],
+  "fixed": ["V"],
+  "ruv": {
+    "prop": [0.232],
+    "add": [0.0001]
+  },
+  "misc": {
+    "model_type": "1cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Minichmayr et al. J. Antimicrob Chemother. 2018",
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/29425283"
+    }
+  ],
+  "version": "0.2.17"
+}

--- a/inst/models/pk_meropenem_ojeanson.json5
+++ b/inst/models/pk_meropenem_ojeanson.json5
@@ -1,0 +1,90 @@
+{
+  "id": "pk_meropenem_ojeanson",
+  "ode_code": "\
+    dAdt[0] = -(CLi/Vi)*A[0] \
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[1] = (CONC > MIC) \
+    dAdt[2] = (CONC > (4 * MIC)) \
+    dAdt[3] = (CONCF > MIC) \
+    dAdt[4] = (CONCF > (4 * MIC)) \
+    dAdt[5] = CONC \
+    TGTMIC = A[1] \
+    TGT4MIC = A[2] \
+    FTGTMIC = A[3] \
+    FTGT4MIC = A[4] \
+  ",
+  "pk_code": "\
+    FSEX = pow(0.742, 1.0-SEX) \
+    FRACE = pow(1.212, RACE_BLACK) \
+    GFRi = 186 * pow(CR, -1.154) * FSEX * FRACE * pow(AGE, -0.203) \
+    RFS = 0 \
+    if (GFRi > 120) RFS = 1 \
+    IRRT = 0 \
+    if (IHD > 0) IRRT = 1 \
+    if (SLED > 0) IRRT = 1 \
+    CLcov1 = CLNR + 0.058 * GFRi \
+    CLcov2 = CLcov1 * (1.0 - CRRT) + 6.38 * CRRT \
+    CLcov3 = CLcov2 * (1.0 - RFS) + 13.9 * RFS \
+    CLcov4 = CLcov3 + 0.6 * ((UO / 845) - 1.0) \
+    CLcov5 = CLcov4 * (1.0 - IRRT) + 11 * IRRT \
+    CLi = CL * CLcov5 \
+    Vi = V \
+  ",
+  "n_comp": 6,
+  "obs": {
+    "cmt": 1,
+    "scale": "Vi"
+  },
+  "dose": {
+    "cmt": 1,
+    "bioav": [
+      1
+    ]
+  },
+  "covariates": [
+    "AGE",
+    "CR",
+    "SEX",
+    "RACE_BLACK",
+    "UO",
+    "CRRT",
+    "IHD",
+    "SLED",
+    "MIC",
+    "FU"
+  ],
+  "variables": [
+    "FSEX", "FRACE", "GFRi", "RFS", "IRRT", "CLcov1", "CLcov2", "CLcov3",
+    "CLcov4", "CLcov5", "CLi", "Vi","CONC", "CONCF", "TGTMIC", "TGT4MIC",
+    "FTGTMIC", "FTGT4MIC"
+  ],
+  "parameters": {
+    "CL": 1.0,
+    "CLNR": 1.36,
+    "V": 43.9
+  },
+  "fixed": ["CLNR"],
+  "omega_matrix": [
+    0.0906302,
+    0, 0.569496
+  ],
+  "ruv": {
+    "prop": [0.313],
+    "add": [0.01]
+  },
+  "misc": {
+    "model_type": "1cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "OJeanson, A., et al.(2021). European Journal of Drug Metabolism and Pharmacokinetics.",
+      "url": "https://doi.org/10.1007/s13318-021-00709-w"
+    }
+  ],
+  "version": "0.1.0"
+}

--- a/inst/models/pk_meropenem_pokorna.json5
+++ b/inst/models/pk_meropenem_pokorna.json5
@@ -1,0 +1,56 @@
+{
+  "id": "pk_meropenem_pokorna",
+  "ode_code": "\
+    dAdt[0] = -(CLi/Vi)*A[0] \
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[1] = (CONC > MIC) \
+    dAdt[2] = (CONC > (4 * MIC)) \
+    dAdt[3] = (CONCF > MIC) \
+    dAdt[4] = (CONCF > (4 * MIC)) \
+    dAdt[5] = CONC \
+    TGTMIC = A[1] \
+    TGT4MIC = A[2] \
+    FTGTMIC = A[3] \
+    FTGT4MIC = A[4] \
+  ",
+  "pk_code": "\
+    CLi = CL * (WT / 7.88) \
+    Vi = V * (WT / 7.88) * pow(1.0 + V_CRRT, CRRT) \
+  ",
+  "n_comp": 6,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRRT", "MIC", "FU" ],
+  "variables": [ 
+    "CLi", "Vi", "CONC", "CONCF", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC" 
+  ],
+  "parameters" : {
+    "CL": 1.09,
+    "V": 3.98,
+    "V_CRRT": 1.04
+  },
+  "fixed": ["V_CRRT"],
+  "omega_matrix": [
+    0.0887,
+    0.0000, 0.9160
+  ],
+  "ruv": {
+    "prop": [0.17]
+  },
+  "misc": {
+    "model_type": "1cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Pokorná P et al. Antibiotics 2024",
+      "url": "https://www.mdpi.com/2079-6382/13/5/419",
+      "doi": "10.3390/antibiotics13050419"
+    }
+  ],
+  "version": "0.1.0"
+}

--- a/inst/models/pk_meropenem_rapp.json5
+++ b/inst/models/pk_meropenem_rapp.json5
@@ -1,0 +1,64 @@
+{
+  "id": "pk_meropenem_rapp",
+  "ode_code": "\
+    dAdt[0] = -(Qi/Vi)*A[0] + (Qi/V2i)*A[1] -(CLtot/Vi)*A[0] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC = A[0]/Vi;\
+    CONCF = CONC * FU \
+    dAdt[2] = A[1]/Vi \
+    dAdt[3] = (CONC > MIC)\
+    dAdt[4] = (CONC > (4 * MIC)) \
+    dAdt[5] = (CONCF > MIC) \
+    dAdt[6] = (CONCF > (4 * MIC)) \
+    dAdt[7] = CONC \
+    AUC = A[2] \
+    TGTMIC = A[3] \
+    TGT4MIC = A[4] \
+    FTGTMIC = A[5] \
+    FTGT4MIC = A[6] \
+  ",
+  "pk_code": "\
+    if(CRRT == 1) { \
+      CLi = 0.9 * CL * pow(WT/70, 0.75); \
+    } else { \
+      CLi = CL * pow(WT/70, 0.75) * pow(CRCL * 16.6667/100, 0.378); \
+    } \
+    CLtot = CLi + CL_HEMO \
+    Vi = V * WT/70 \
+    Qi = Q * pow(WT/70, 0.75) \
+    V2i = V2 * WT/70 \
+  ",
+  "n_comp": 8,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRCL", "MIC", "FU", "CRRT", "CL_HEMO" ],
+  "variables": [ "CLi", "CLtot", "Vi", "Qi", "V2i", "TGTMIC", "TGT4MIC",  "FTGTMIC", "FTGT4MIC", "CONC", "CONCF"],
+  "parameters" : {
+    "CL": 6.82,
+    "V": 40.6,
+    "Q": 1,
+    "V2": 9.2
+  },
+  "omega_matrix": [
+    0.16,
+    0, 1.0
+  ],
+  "fixed": ["Q", "V2"],
+  "ruv": {
+    "prop": [0.388],
+    "add": [0.0001]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Rapp et al. Eur. J. Clin. Pharmacol. 2020",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31654149/"
+    }
+  ],
+  "version": "0.1.5"
+}

--- a/inst/models/pk_meropenem_roberts.json5
+++ b/inst/models/pk_meropenem_roberts.json5
@@ -1,0 +1,83 @@
+{
+  "id": "pk_meropenem_roberts",
+  "ode_code": "\
+    CLrrti = CLrrt_avg * exp(kappa_CLrrt) \
+    CLbodyi = CLbody_avg * exp(kappa_CL) \
+    CLi = CLrrti + CLbodyi \
+    Vi = V_avg * exp(kappa_V) \
+    dAdt[0] = -(CLi/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC = A[0]/Vi;\
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC > MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF > MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    CLrrt_avg = CLrrt * pow(PFR/4.0, 0.39) * exp(0.48 * SLED) \
+    CLbody_avg = CL * exp(0.61 * (1.0 - RUO)) \
+    CL_avg = CLrrt_avg + CLbody_avg \
+    V_avg = V \
+    V2_avg = V2 \
+    V2i = V2_avg \
+    Qi = Q \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "PFR", "SLED", "RUO", "MIC", "FU" ],
+  "variables": [ 
+    "CLrrt_avg", "CLrrti", "CLbody_avg", "CLbodyi", "CL_avg", "CLi",
+    "V_avg", "V2_avg", "Vi", "Qi", "V2i", "CONC", "CONCF",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC"
+  ],
+  "parameters" : {
+    "CLrrt": 2.2,
+    "CL": 2.1,
+    "V": 18.8,
+    "V2": 15.3,
+    "Q": 11.1
+  },
+  "fixed": [],
+  "iov": {
+    "use": true,
+    "cv": {
+      "CLrrt": 0.16,
+      "CL": 0.5,
+      "V": 0.25
+    },
+    "n_bins": 3,
+    "bins": [0, 48, 96, 9999]
+  },
+  "omega_matrix": [
+    0.0729,
+    0, 0.25,
+    0, 0, 0.2601,
+    0, 0, 0, 0.2601,
+    0, 0, 0, 0, 0.5625
+  ],
+  "ruv": {
+    "prop": [0.1],
+    "add": [0.01]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Roberts, J.A., et al., (2025). Intensive Care Medicine",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12405346/"
+    }
+  ],
+  "version": "0.1.1"
+}

--- a/inst/models/pk_meropenem_saito.json5
+++ b/inst/models/pk_meropenem_saito.json5
@@ -1,0 +1,134 @@
+{
+  "id": "pk_meropenem_saito",
+  "ode_code": "\
+    dAdt[0] = -(CLi/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC = A[0]/Vi \
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC > MIC) \
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF > MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    if (AGE < 0.0192) { \
+      HR_TACH = 180 \
+      HR_BRAD = 100 \
+      RR_THRESH = 50 \
+      WBC_HI = 34 \
+      WBC_LO = -999 \
+      SBP_THRESH = 65 \
+    } else if (AGE < 0.0833) { \
+      HR_TACH = 180 \
+      HR_BRAD = 100 \
+      RR_THRESH = 40 \
+      WBC_HI = 19.5 \
+      WBC_LO = 5.0 \
+      SBP_THRESH = 75 \
+    } else if (AGE < 2.0) { \
+      HR_TACH = 180 \
+      HR_BRAD = 90 \
+      RR_THRESH = 34 \
+      WBC_HI = 17.5 \
+      WBC_LO = 5.0 \
+      SBP_THRESH = 100 \
+    } else if (AGE < 6.0) { \
+      HR_TACH = 140 \
+      HR_BRAD = -999 \
+      RR_THRESH = 22 \
+      WBC_HI = 15.5 \
+      WBC_LO = 6.0 \
+      SBP_THRESH = 94 \
+    } else if (AGE < 13.0) { \
+      HR_TACH = 130 \
+      HR_BRAD = -999 \
+      RR_THRESH = 18 \
+      WBC_HI = 13.5 \
+      WBC_LO = 4.5 \
+      SBP_THRESH = 105 \
+    } else { \
+      HR_TACH = 110 \
+      HR_BRAD = -999 \
+      RR_THRESH = 14 \
+      WBC_HI = 11 \
+      WBC_LO = 4.5 \
+      SBP_THRESH = 117 \
+    } \
+    HR_FLAG = 0 \
+    if (HR > HR_TACH || HR < HR_BRAD && HR_BRAD > 0) { \
+      HR_FLAG = 1 \
+    } \
+    RR_FLAG = 0 \
+    if (RR > RR_THRESH) { \
+      RR_FLAG = 1 \
+    } \
+    WBC_FLAG = 0 \
+    if (WBC > WBC_HI || WBC < WBC_LO && WBC_LO > 0) { \
+      WBC_FLAG = 1 \
+    } \
+    SBP_FLAG = 0 \
+    if (SBP < SBP_THRESH) { \
+      SBP_FLAG = 1 \
+    } \
+    SIRS_SCORE = HR_FLAG + RR_FLAG + WBC_FLAG + SBP_FLAG \
+    SIRS_yes = 0 \
+    if (SIRS_SCORE >= 2) { \
+      SIRS_yes = 1 \
+    } \
+    BSA = 0.016667 * pow(WT, 0.5) * pow(HT, 0.5) \
+    CRCL = ((0.413 * HT) / CR) * (BSA/1.73) \
+    CLi = CL * pow(CRCL/38.2, 0.19) * pow(1 + 0.35, SIRS_yes) * WT \
+    Vi = V * pow(1 + 0.66, CRRT) * WT \
+    V2i = V2 * WT \
+    Qi = Q * WT \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "HT", "WT", "CR", "AGE", "HR", "RR", "WBC", "SBP", "CRRT", "MIC", "FU" ],
+  "variables": [
+    "HR_TACH", "HR_BRAD", "RR_THRESH", "WBC_HI", "WBC_LO", "SBP_THRESH",
+    "HR_FLAG", "RR_FLAG", "WBC_FLAG", "SBP_FLAG", "SIRS_SCORE",
+    "SIRS_yes", "BSA", "CRCL", "CLi", "Vi", "V2i", "Qi",
+    "CONC", "CONCF", "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC"
+  ],
+  "parameters": {
+    "CL": 0.45,
+    "V": 0.49,
+    "V2": 0.34,
+    "Q": 0.28
+  },
+  "fixed": [ "V2", "Q" ],
+  "omega_matrix": [
+    0.0734,
+    0.0000, 0.0992
+  ],
+  "ruv": {
+    "prop": [0.3323]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true,
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Saito J et al. Antimicrob Agents Chemother 2021",
+      "url": "https://www.mdpi.com/2079-6382/13/5/419",
+      "doi": "10.3390/antibiotics13050419"
+    },
+    {
+      "ref": "Goldstein et al. Pediatric Critical Care Medicine 2005",
+      "url": "http://journals.lww.com/00130478-200501000-00002",
+      "doi": "10.1097/01.PCC.0000149131.72248.E6"
+    }
+  ],
+  "version": "0.1.1"
+}

--- a/inst/models/pk_meropenem_sjovall.json5
+++ b/inst/models/pk_meropenem_sjovall.json5
@@ -1,0 +1,66 @@
+{
+  "id": "pk_meropenem_sjovall",
+  "ode_code": "\
+    dAdt[0] = -(CLi/Vi)*A[0] - KCPi*A[0] + KPCi*A[1]  \
+    dAdt[1] = +KCPi*A[0] - KPC*A[1]  \
+    CONC = A[0]/Vi;\
+    CONCF = CONC * FU \
+    dAdt[2] = (CONC>MIC)\
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    CRCLi = CRCL * 16.666667 \
+    CLi = CL * (2 + CRCLi * 0.083)  \
+    Vi = V \
+    KCPi = KCP \
+    KPCi = KPC \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "parameters": {
+    "CL": 7.34,
+    "V": 16.155,
+    "KCP": 1.579,
+    "KPC": 2.683
+  },
+  "omega_matrix": [
+    0.165,
+    0, 0.143,
+    0, 0, 0.9025,
+    0, 0, 0, 3.996
+  ],
+  "ruv": {
+    "prop": [0.15],
+    "add": [1]
+  },
+  "covariates": ["CRCL", "MIC", "FU"],
+  "variables": [
+    "CLi", "CRCLi", "Vi", "KCPi", "KPCi",
+    "CONC", "CONCF", "TGTMIC", "TGT4MIC",
+    "FTGTMIC", "FTGT4MIC"
+  ],
+  "fixed": [],
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": false,
+    "source": "pmetrics",
+    "int_step_size": 0.01
+  },
+  "references": [
+    {
+      "ref": "Sjovall F et al. J Antimicrob Chemother 2018",
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/28961812"
+    }
+  ],
+  "version": "0.2.18"
+}

--- a/inst/models/pk_piperacillin_andersen.json5
+++ b/inst/models/pk_piperacillin_andersen.json5
@@ -1,0 +1,60 @@
+{
+  "id": "pk_piperacillin_andersen",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] =                + (Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC    = A[0]/Vi \
+    CONCF   = CONC * FU \
+    dAdt[2] = (CONC>MIC)\
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC  = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+  ",
+  "pk_code": "\
+    TVCL = CLnr + TH_CRCL * (CRCL*16.6667) \
+    CLi = CL * TVCL \
+    CLtot = CLi + CL_HEMO \
+    Vi = V \
+    Qi = Q \
+    V2i = V2 \
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "Vi" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "CRCL", "MIC", "FU", "CL_HEMO" ],
+  "variables": [ "TVCL", "CLi", "CLtot", "Vi", "Qi", "V2i", "TGTMIC","TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF" ],
+  "parameters" : {
+    "CL": 1,
+    "CLnr": 2.23,
+    "V": 12.4,
+    "Q": 3.54,
+    "V2": 3.48,
+    "TH_CRCL": 0.0757
+  },
+  "omega_matrix": [
+    0.08821
+  ],
+  "fixed": ["V", "Q", "V2", "TH_CRCL", "CLnr"],
+  "ruv": {
+    "prop": [0.115],
+    "add": [0.0001]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Andersen MG et al. Population pharmacokinetics of piperacillin in sepsis patients: should alternative dosing strategies be considered? Antimicrob Agents Chemother (2018) 62:e02306-17",
+      "url": "http://aac.asm.org/lookup/doi/10.1128/AAC.02306-17"
+    }
+  ],
+  "version": "0.2.14"
+}

--- a/inst/models/pk_piperacillin_delattre.json5
+++ b/inst/models/pk_piperacillin_delattre.json5
@@ -1,0 +1,67 @@
+{
+  "id": "pk_piperacillin_delattre",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] - (Qi/Vi)*A[0] + (Qi/V2i)*A[1] \
+    dAdt[1] = +(Qi/Vi)*A[0] - (Qi/V2i)*A[1] \
+    CONC    = A[0] / Vi \
+    CONCF   = CONC * FU \
+    dAdt[2] = (CONC>MIC)\
+    dAdt[3] = (CONC > (4 * MIC)) \
+    dAdt[4] = (CONCF>MIC) \
+    dAdt[5] = (CONCF > (4 * MIC)) \
+    dAdt[6] = CONC \
+    TGTMIC = A[2] \
+    TGT4MIC = A[3] \
+    FTGTMIC = A[4] \
+    FTGT4MIC = A[5] \
+    ",
+  "pk_code": "\
+    CRCLi = (CRCL * 16.66667) * (70.0/WT)\
+    CLi = CL * pow((CRCLi/100.0), TH_CRCL) * pow(WT/70.0, 0.75)\
+    CLtot = CLi + CL_HEMO\
+    Vi = V * (WT/70.0)\
+    Qi = Q * pow(WT/70.0, 0.75)\
+    V2i = V2 * (WT/70.0)\
+  ",
+  "n_comp": 7,
+  "obs": { "cmt": 1, "scale": "V * (WT/70.0)" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "WT", "CRCL", "CL_HEMO", "MIC", "FU" ],
+  "variables": [ 
+    "CLi", "Vi", "Qi", "V2i", "CRCLi", "CLtot", "TGTMIC", "TGT4MIC",
+    "FTGTMIC", "FTGT4MIC", "CONC", "CONCF"
+  ],
+  "parameters" : {
+    "CL": 9.97,
+    "V": 24.0,
+    "Q": 5.48,
+    "V2": 8.11,
+    "TH_CRCL": 0.62
+  },
+  "fixed": ["Q", "V2", "TH_CRCL"],
+  "omega_matrix": [
+    0.265225,
+    0.0584525, 0.206116
+  ],
+  "ruv": {
+    "prop": [0.307],
+    "add": [1.9]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Delattre et al. Clin Biochem 2012",
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/22503878"
+    },
+    {
+      "ref": "Delattre et al. Therapeutic Drug Monitoring 2010",
+      "url": "https://doi.org/10.1097/ftd.0b013e3181f675c2"
+    }
+  ],
+  "version": "0.2.14"
+}

--- a/inst/models/pk_piperacillin_klastrup.json5
+++ b/inst/models/pk_piperacillin_klastrup.json5
@@ -1,0 +1,57 @@
+{
+  "id": "pk_piperacillin_klastrup",
+  "ode_code": "\
+    dAdt[0] = -(CLtot/Vi)*A[0] \
+    CONC    = A[0] / Vi \
+    CONCF   = CONC * FU \
+    dAdt[1] = (CONC>MIC)\
+    dAdt[2] = (CONC > (4 * MIC)) \
+    dAdt[3] = (CONCF>MIC) \
+    dAdt[4] = (CONCF > (4 * MIC)) \
+    dAdt[5] = CONC \
+    TGTMIC = A[1] \
+    TGT4MIC = A[2] \
+    FTGTMIC = A[3] \
+    FTGT4MIC = A[4] \
+    ",
+  "pk_code": "\
+    CRCLi = (CRCL * 16.66667) \
+    CLi = CL * (2.25 + (0.119 * CRCLi)) \
+    CLtot = CLi + CL_HEMO\
+    Vi = V \
+  ",
+  "n_comp": 6,
+  "obs": { "cmt": 1, "scale": "V" },
+  "dose": { "cmt": 1, "bioav": [1] },
+  "covariates": [ "CRCL", "CL_HEMO", "MIC", "FU" ],
+  "variables": [ 
+    "CLi", "Vi", "CRCLi", "CLtot", "TGTMIC", "TGT4MIC",
+    "FTGTMIC", "FTGT4MIC", "CONC", "CONCF"
+  ],
+  "parameters" : {
+    "CL": 1,
+    "V": 35.8
+  },
+  "fixed": [ "V" ],
+  "omega_matrix": [
+    0.3295
+  ],
+  "ruv": {
+    "prop": [ 0.226 ],
+    "add": [ 0.0001 ]
+  },
+  "misc": {
+    "model_type": "1cmt_iv",
+    "linearity": "linear",
+    "timevarying_parameter": false,
+    "init_parameter": true
+  },
+  "references": [
+    {
+      "ref": "Klastrup et al. AAC 2020",
+      "url": "https://doi.org/10.1128/aac.02556-19",
+      "doi": "10.1128/aac.02556-19"
+    }
+  ],
+  "version": "0.1.3"
+}

--- a/inst/models/pk_piperacillintazobactam_colin.json5
+++ b/inst/models/pk_piperacillintazobactam_colin.json5
@@ -1,0 +1,121 @@
+{
+  "id": "pk_piperacillintazobactam_colin",
+ "ode_code": "\
+    dAdt[0] = -(CL_tot_pip/V_pip_i)*A[0] - (Q_pip_i/V_pip_i)*A[0] + (Q_pip_i/V2_pip_i)*A[1] \
+    dAdt[1] =                          + (Q_pip_i/V_pip_i)*A[0] - (Q_pip_i/V2_pip_i)*A[1] \
+    CONC_pip = A[0]/V_pip_i \
+    CONCF_pip = CONC_pip * FUPIP \
+    dAdt[2] = -(CL_tot_taz/V_taz_i)*A[2] - (Q_taz_i/V_taz_i)*A[2] + (Q_taz_i/V2_taz_i)*A[3] \
+    dAdt[3] =                          + (Q_taz_i/V_taz_i)*A[2] - (Q_taz_i/V2_taz_i)*A[3] \
+    CONC_taz = A[2]/V_taz_i \
+    CONCF_taz = CONC_taz * FUTAZ \
+    dAdt[4] = (CONC_pip > MICPIP) \
+    dAdt[5] = (CONC_pip > (4 * MICPIP)) \
+    dAdt[6] = (CONCF_pip > MICPIP) \
+    dAdt[7] = (CONCF_pip > (4 * MICPIP)) \
+    dAdt[8] = CONC_pip \
+    dAdt[9] = (CONC_taz > MICTAZ) \
+    dAdt[10] = (CONCF_taz > MICTAZ) \
+    dAdt[11] = CONC_taz \
+    TGTMIC_pip   = A[4] \
+    TGT4MIC_pip  = A[5] \
+    FTGTMIC_pip  = A[6] \
+    FTGT4MIC_pip = A[7] \
+    AUC_pip      = A[8] \
+    TGTMIC_taz   = A[9] \
+    FTGTMIC_taz  = A[10] \
+    AUC_taz      = A[11] \
+    CONC_pip_dbs = CONC_pip * 0.3678794 \
+    CONC_taz_dbs = CONC_taz * 0.4484312 \
+    CONC = CONC_pip \
+    CONCF = CONCF_pip \
+    TGTMIC = TGTMIC_pip \
+    FTGTMIC = FTGTMIC_pip \
+    TGT4MIC = TGT4MIC_pip \
+    FTGT4MIC = FTGT4MIC_pip \
+  ",
+  "pk_code": "\
+    FSIZE = WT/70.0 \
+    RPMA = (35.0 + (40.0/52.0)) \
+    MGAM = exp(1.21) \
+    ME50 = exp(0.0358)  \
+    FMAT = pow(PMA/52.0, MGAM)/(pow(PMA/52.0, MGAM)+pow(ME50,MGAM)) \
+    RFMAT= pow(RPMA, MGAM)/(pow(RPMA, MGAM)+pow(ME50,MGAM)) \
+    DGAM = exp(0.653) \
+    PD50 = exp(4.49) \
+    PFD  = pow(PD50, DGAM)/(pow(PMA/52.0, DGAM)+pow(PD50, DGAM)) \
+    PRFD = pow(PD50, DGAM)/(pow(RPMA, DGAM)+pow(PD50, DGAM)) \
+    TD50 = exp(4.12) \
+    TFD  = pow(TD50, DGAM)/(pow(PMA/52.0, DGAM)+pow(TD50, DGAM)) \
+    TRFD = pow(TD50, DGAM)/(pow(RPMA, DGAM)+pow(TD50, DGAM)) \
+    STCR = exp(1.42-(1.17*(pow((PMA/52.0)/100.0, -0.5)))-(0.203*(pow((PMA/52.0)/100.0, -0.5))*log((PMA/52.0)/100.0))) \
+    ESCR = exp(-1.06) \
+    FSCR = exp(-ESCR*(CR-STCR)) \
+    V_pip_i = V_pip * V1eta * FSIZE \
+    CL_pip_i = CL_pip * pow(FSIZE, 0.75) * (FMAT / RFMAT) * (PFD/PRFD) * FSCR \
+    CL_tot_pip = CL_pip_i + CL_HEMO \
+    V2_pip_i = V2_pip * V2eta * FSIZE \
+    V2SZ = V2_pip_i / exp(2.45) \
+    Q_pip_i = Q_pip * Qeta * pow(V2SZ, 0.75) \
+    V_taz_i = V_taz * V1eta * FSIZE \
+    CL_taz_i = CL_taz * pow(FSIZE, 0.75) * (FMAT / RFMAT) * (TFD / TRFD) * FSCR \
+    CL_tot_taz = CL_taz_i + CL_HEMO \
+    V2_taz_i = V2_taz * V2eta * FSIZE \
+    V4SZ = V2_taz_i / exp(2.62) \
+    Q_taz_i = Q_taz * Qeta * pow(V4SZ, 0.75) \
+  ",
+  "n_comp": 12,
+  "obs": {
+    "variable": [ "CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz", "CONC_pip_dbs", "CONC_taz_dbs"]
+  },
+  "dose": { "cmt": 1, "bioav": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0] },
+  "covariates": [ "MICPIP", "MICTAZ", "FUPIP", "FUTAZ", "PMA", "WT", "CR", "CL_HEMO" ],
+  "variables": [
+    "CL_pip_i", "V_pip_i", "Q_pip_i", "V2_pip_i", "CL_tot_pip",
+    "CL_taz_i", "V_taz_i", "Q_taz_i", "V2_taz_i", "CL_tot_taz",
+    "CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz", "CONC_pip_dbs", "CONC_taz_dbs",
+    "TGTMIC_pip", "TGT4MIC_pip", "FTGTMIC_pip", "FTGT4MIC_pip", "TGTMIC_taz",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF",
+    "FTGTMIC_taz", "AUC_pip", "AUC_taz", "FSIZE", "RPMA", "MGAM",
+    "ME50", "FMAT", "RFMAT", "DGAM", "PD50", "PFD", "PRFD", "TD50",
+    "TFD", "TRFD", "STCR", "ESCR", "FSCR", "V4SZ", "V2SZ"
+  ],
+  "parameters" : {
+    "CL_pip": 10.5910,
+    "CL_taz": 9.5831,
+    "V1eta": 1.0,
+    "V2eta": 1.0,
+    "Qeta": 1.0,
+    "V_pip": 10.3812,
+    "V2_pip": 11.5884,
+    "Q_pip": 15.1803,
+    "V_taz": 10.4856,
+    "V2_taz": 13.7357,
+    "Q_taz": 16.7769
+  },
+  "fixed": ["V_pip", "Q_pip", "V2_pip", "V_taz", "Q_taz", "V2_taz"],
+  "omega_matrix": [
+    0.171,
+    0, 0.159,
+    0, 0, 0.167,
+    0, 0, 0, 0.5,
+    0, 0, 0, 0, 0.358
+  ],
+  "ruv": {
+    "prop": [ 0.3016621, 0.2846050, 0.3646917, 0.2846050, 0.3016621, 0.2846050 ],
+    "add": [ 0.1469694, 0.001, 0.7469940, 0.001, 0.1469694, 0.001 ]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "nonlinear",
+    "timevarying_parameter": false,
+    "init_parameter": false
+  },
+  "references": [
+    {
+      "ref": "Kong, D., et al. Clinical Pharmacokinetics. 2024.",
+      "url": "https://link.springer.com/article/10.1007/s40262-024-01460-6"
+    }
+  ],
+  "version": "0.1.12"
+}

--- a/inst/models/pk_piperacillintazobactam_hemmersbachmiller.json5
+++ b/inst/models/pk_piperacillintazobactam_hemmersbachmiller.json5
@@ -1,0 +1,86 @@
+{
+  "id": "pk_piperacillintazobactam_hemmersbachmiller",
+  "ode_code": "\
+    dAdt[0] = -(CL_tot_pip/V_pip_i)*A[0]  \
+    CONC_pip = A[0]/V_pip_i \
+    CONCF_pip = CONC_pip * FUPIP \
+    dAdt[1] = -(CL_tot_taz/V_taz_i)*A[1] \
+    CONC_taz = A[1]/V_taz_i \
+    CONCF_taz = CONC_taz * FUTAZ \
+    dAdt[2] = (CONC_pip > MICPIP) \
+    dAdt[3] = (CONC_pip > (4.0 * MICPIP)) \
+    dAdt[4] = (CONCF_pip > MICPIP) \
+    dAdt[5] = (CONCF_pip > (4.0 * MICPIP)) \
+    dAdt[6] = CONC_pip \
+    dAdt[7] = (CONC_taz > MICTAZ) \
+    dAdt[8] = (CONCF_taz > MICTAZ) \
+    dAdt[9] = CONC_taz \
+    TGTMIC_pip   = A[2] \
+    TGT4MIC_pip  = A[3] \
+    FTGTMIC_pip  = A[4] \
+    FTGT4MIC_pip = A[5] \
+    AUC_pip      = A[6] \
+    TGTMIC_taz   = A[7] \
+    FTGTMIC_taz  = A[8] \
+    AUC_taz      = A[9] \
+    CONC = CONC_pip \
+    CONCF = CONCF_pip \
+    TGTMIC = TGTMIC_pip \
+    FTGTMIC = FTGTMIC_pip \
+    TGT4MIC = TGT4MIC_pip \
+    FTGT4MIC = FTGT4MIC_pip \
+  ",
+  "pk_code": "\
+    CRCLn = CRCL * 16.66667 / 69.0 \
+    CL_pip_i = CL_pip * (4.09 * CRCLn + 2.44) \
+    CL_tot_pip = CL_pip_i + CL_HEMO \
+    V_pip_i  = V_pip * (WT/89.0) \
+    CL_taz_i = CL_taz * (5.18 * CRCLn + 1.14 * pow(WT/89.0, 0.75)) \
+    CL_tot_taz = CL_taz_i + CL_HEMO \
+    V_taz_i  = V_taz * (WT/89.0) \
+  ",
+  "n_comp": 10,
+  "obs": {
+    "variable": [ "CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz"]
+  },
+  "dose": { "cmt": 1, "bioav": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] },
+  "covariates": [ "MICPIP", "MICTAZ", "FUPIP", "FUTAZ", "WT", "CRCL", "CL_HEMO" ],
+  "variables": [
+    "CL_pip_i", "V_pip_i", "CL_tot_pip",
+    "CL_taz_i", "V_taz_i", "CL_tot_taz",
+    "CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz",
+    "TGTMIC_pip", "TGT4MIC_pip", "FTGTMIC_pip", "FTGT4MIC_pip",
+    "TGTMIC_taz", "FTGTMIC_taz", "AUC_pip", "AUC_taz", "CRCLn",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF"
+  ],
+  "parameters" : {
+    "CL_pip": 1.0,
+    "V_pip": 31.8,
+    "CL_taz": 1.0,
+    "V_taz": 40.3
+  },
+  "omega_matrix": [
+    0.2209,
+    0, 0.0625,
+    0, 0, 0.2209,
+    0, 0, 0, 0.0441
+  ],
+  "fixed": [],
+  "ruv": {
+    "prop": [ 0.358, 0.3, 0.358, 0.3],
+    "add": [ 0.0488, 0.562, 0.0488, 0.562]
+  },
+  "misc": {
+    "model_type": "1cmt_iv",
+    "linearity": "nonlinear",
+    "timevarying_parameter": false,
+    "init_parameter": false
+  },
+  "references": [
+    {
+      "ref": "Hemmersbach, M., et al. Clinical Pharmacokinetics, 2023",
+      "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9969806/"
+    }
+  ],
+  "version": "0.1.10"
+}

--- a/inst/models/pk_piperacillintazobactam_kim.json5
+++ b/inst/models/pk_piperacillintazobactam_kim.json5
@@ -1,0 +1,113 @@
+{
+  "id": "pk_piperacillintazobactam_kim",
+ "ode_code": "\
+    dAdt[0] = -(CL_tot_pip/V_pip_i)*A[0] - (Q_pip_i/V_pip_i)*A[0] + (Q_pip_i/V2_pip_i)*A[1] \
+    dAdt[1] =                            + (Q_pip_i/V_pip_i)*A[0] - (Q_pip_i/V2_pip_i)*A[1] \
+    CONC_pip = A[0]/V_pip_i \
+    CONCF_pip = CONC_pip * FUPIP \
+    dAdt[2] = -(CL_tot_taz/V_taz_i)*A[2] - (Q_taz_i/V_taz_i)*A[2] + (Q_taz_i/V2_taz_i)*A[3] \
+    dAdt[3] =                            + (Q_taz_i/V_taz_i)*A[2] - (Q_taz_i/V2_taz_i)*A[3] \
+    CONC_taz = A[2]/V_taz_i \
+    CONCF_taz = CONC_taz * FUTAZ \
+    dAdt[4] = (CONC_pip > MICPIP) \
+    dAdt[5] = (CONC_pip > (4 * MICPIP)) \
+    dAdt[6] = (CONCF_pip > MICPIP) \
+    dAdt[7] = (CONCF_pip > (4 * MICPIP)) \
+    dAdt[8] = CONC_pip \
+    dAdt[9] = (CONC_taz > MICTAZ) \
+    dAdt[10] = (CONCF_taz > MICTAZ) \
+    dAdt[11] = CONC_taz \
+    TGTMIC_pip   = A[4] \
+    TGT4MIC_pip  = A[5] \
+    FTGTMIC_pip  = A[6] \
+    FTGT4MIC_pip = A[7] \
+    AUC_pip      = A[8] \
+    TGTMIC_taz   = A[9] \
+    FTGTMIC_taz  = A[10] \
+    AUC_taz      = A[11] \
+    CONC = CONC_pip \
+    CONCF = CONCF_pip \
+    TGTMIC = TGTMIC_pip \
+    FTGTMIC = FTGTMIC_pip \
+    TGT4MIC = TGT4MIC_pip \
+    FTGT4MIC = FTGT4MIC_pip \
+  ",
+  "pk_code": "\
+    if(CYSC <= 0.8) {  \
+      CKDEPICYSC = 133 * pow(CYSC/0.8, -0.499) * pow(0.996, AGE) * pow(0.932, 1-SEX) ;\
+    } else { \
+      CKDEPICYSC = 133 * pow(CYSC/0.8, -1.328) * pow(0.996, AGE) * pow(0.932, 1-SEX) ;\
+    } \
+    CL_pip_i = CL_pip * exp(0.00932 * (CKDEPICYSC - 52.77)) * pow(WT/70,0.75) \
+    CL_tot_pip = CL_pip_i + CL_HEMO \
+    V_pip_ecmo_i = V_pip_ecmo * WT/70 * V1pipecmoeta \
+    V_pip_necmo_i = V_pip_necmo * WT/70 * V1pipnecmoeta \
+    V_pip_i = (ECMO * V_pip_ecmo_i) + ((1 - ECMO) * V_pip_necmo_i) \
+    Q_pip_i = Q_pip * pow(WT/70,0.75) \
+    V2_pip_i = V2_pip * WT/70 \
+    CL_taz_i = CL_taz * exp(0.0113 * (CKDEPICYSC - 52.77)) * pow(WT/70,0.75) \
+    CL_tot_taz = CL_taz_i + CL_HEMO \
+    V_taz_ecmo_i = V_taz_ecmo * WT/70 * V1tazecmoeta \
+    V_taz_necmo_i = V_taz_necmo * WT/70 * V1taznecmoeta \
+    V_taz_i = (ECMO * V_taz_ecmo_i) + ((1 - ECMO) * V_taz_necmo_i) \
+    Q_taz_i = Q_taz * pow(WT/70,0.75) \
+    V2_taz_i = V2_taz * WT/70  \
+  ",
+  "n_comp": 12,
+  "obs": {
+    "variable": ["CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz"]
+  },
+  "dose": { "cmt": 1, "bioav": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0] },
+  "covariates": ["MICPIP", "MICTAZ", "FUPIP", "FUTAZ", "AGE", "WT", "CYSC", "SEX", "ECMO", "CL_HEMO"],
+  "variables": [
+    "CL_pip_i", "V_pip_ecmo_i", "V_pip_necmo_i", "V_pip_i", "Q_pip_i", 
+    "V2_pip_i", "CL_tot_pip","CL_taz_i", "V_taz_ecmo_i", "V_taz_necmo_i", "V_taz_i",
+    "Q_taz_i", "V2_taz_i", "CL_tot_taz", "CONC_pip", "CONC_taz", "CONCF_pip", 
+    "CONCF_taz", "TGTMIC_pip", "TGT4MIC_pip", "FTGTMIC_pip", "FTGT4MIC_pip", 
+    "TGTMIC_taz", "FTGTMIC_taz", "AUC_pip", "AUC_taz", "CKDEPICYSC",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF"
+  ],
+  "parameters" : {
+    "CL_pip": 5.05,
+    "V_pip_ecmo": 7.38,
+    "V1pipecmoeta": 1.0,
+    "V_pip_necmo": 16.5,
+    "V1pipnecmoeta": 1.0,
+    "Q_pip": 6.28,
+    "V2_pip": 6.27,
+    "CL_taz": 6.33,
+    "V_taz_ecmo": 13.3,
+    "V1tazecmoeta": 1.0,
+    "V_taz_necmo": 20.2,
+    "V1taznecmoeta": 1.0,
+    "Q_taz": 10.5,
+    "V2_taz": 8.96
+  },
+  "fixed": [ "V_pip_ecmo", "V_pip_necmo", "Q_pip", "V2_pip", "V_taz_ecmo", "V_taz_necmo", "Q_taz", "V2_taz" ],
+  "omega_matrix": [
+    0.1136,
+    0, 0.2107,
+    0, 0, 0.4264,
+    0, 0, 0, 0.1436,
+    0, 0, 0, 0, 0.1490,
+    0, 0, 0, 0, 0, 0.4199
+  ],
+  "ruv": {
+    "prop": [ 0.269, 0.229 ],
+    "add": [ 0.001, 0.001 ]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "nonlinear",
+    "timevarying_parameter": false,
+    "init_parameter": false
+  },
+  "references": [
+    {
+      "ref": "Kim et al. Journal of Antimicrobial Chemotherapy 2022",
+      "url": "https://doi.org/10.1093/jac/dkac059",
+      "doi": "10.1093/jac.dkac05910"
+    }
+  ],
+  "version": "0.1.3"
+}

--- a/inst/models/pk_piperacillintazobactam_wallenburg.json5
+++ b/inst/models/pk_piperacillintazobactam_wallenburg.json5
@@ -1,0 +1,120 @@
+{
+  "id": "pk_piperacillintazobactam_wallenburg",
+  "ode_code": "\
+    CLR_pip_i = (CRCL * 16.66667) * CLR_pip * exp(kappa_CLR) \
+    CL_tot_pip = CL_pip_i + CLR_pip_i + CL_HEMO \
+    CLR_taz_i = CLR_pip_i * 1.1 \
+    CL_tot_taz = CL_taz_i + CLR_taz_i + CL_HEMO \
+    dAdt[0] = -(CL_tot_pip/V_pip_i)*A[0] - (Q_pip_i/V_pip_i)*A[0] + (Q_pip_i/V2_pip_i)*A[1] \
+    dAdt[1] =                            + (Q_pip_i/V_pip_i)*A[0] - (Q_pip_i/V2_pip_i)*A[1] \
+    CONC_pip = A[0]/V_pip_i \
+    CONCF_pip = CONC_pip * FUPIP \
+    dAdt[2] = -(CL_tot_taz/V_taz_i)*A[2] - (Q_taz_i/V_taz_i)*A[2] + (Q_taz_i/V2_taz_i)*A[3] \
+    dAdt[3] =                            + (Q_taz_i/V_taz_i)*A[2] - (Q_taz_i/V2_taz_i)*A[3] \
+    CONC_taz = A[2]/V_taz_i \
+    CONCF_taz = CONC_taz * FUTAZ \
+    dAdt[4] = (CONC_pip > MICPIP) \
+    dAdt[5] = (CONC_pip > (4 * MICPIP)) \
+    dAdt[6] = (CONCF_pip > MICPIP) \
+    dAdt[7] = (CONCF_pip > (4 * MICPIP)) \
+    dAdt[8] = (CONC_taz > MICTAZ) \
+    dAdt[9] = (CONCF_taz > MICTAZ) \
+    dAdt[10] = CONC_pip \
+    dAdt[11] = CONC_taz \
+    TGTMIC_pip   = A[4] \
+    TGT4MIC_pip  = A[5] \
+    FTGTMIC_pip  = A[6] \
+    FTGT4MIC_pip = A[7] \
+    TGTMIC_taz   = A[8] \
+    FTGTMIC_taz  = A[9] \
+    AUC_pip      = A[10] \
+    AUC_taz      = A[11] \
+    TGTMIC = TGTMIC_pip \
+    FTGTMIC = FTGTMIC_pip \
+    TGT4MIC = TGT4MIC_pip \
+    FTGT4MIC = FTGT4MIC_pip \
+    CONC = CONC_pip \
+    CONCF = CONCF_pip \
+  ",
+  "pk_code": "\
+    BMI = WT / pow(HT/100.0, 2.0) \
+    if(SEX == 1) {  \
+      FFM = (9270.0 * WT) / (6680.0 + 216.0 * BMI) ;\
+    } else { \
+      FFM = (9270.0 * WT) / (8780.0 + 244.0 * BMI) ;\
+    } ;\
+    ALLOCL= pow(FFM/58.2, 0.75) \
+    ALLOV = FFM/58.2 \
+    CL_pip_i = CL_pip * ALLOCL * ETACL \
+    V_pip_i  = V_pip * ALLOV * ETAV1 \
+    V2_pip_i = V2_pip * ALLOV * ETAV2 \
+    Q_pip_i = Q_pip * ALLOCL \
+    CL_taz_i = CL_taz * ALLOCL * ETACL \
+    V_taz_i  = V_taz * ALLOV * ETAV1 \
+    V2_taz_i = V2_taz * ALLOV * ETAV2 \
+    Q_taz_i = Q_taz * ALLOCL \
+  ",
+  "n_comp": 12,
+  "obs": {
+    "variable": [ "CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz"]
+  },
+  "dose": { "cmt": 1, "bioav": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] },
+  "covariates": [ "MICPIP", "MICTAZ", "FUPIP", "FUTAZ", "WT", "HT", "SEX", "CL_HEMO", "CRCL" ],
+  "variables": [
+    "CL_pip_i", "V_pip_i", "Q_pip_i", "V2_pip_i", "CL_tot_pip",
+    "CL_taz_i", "V_taz_i", "Q_taz_i", "V2_taz_i", "CL_tot_taz",
+    "BMI", "FFM", "ALLOCL", "ALLOV", "CLR_pip_i", "CLR_taz_i",
+    "CONC_pip", "CONC_taz", "CONCF_pip", "CONCF_taz",
+    "TGTMIC_pip", "TGT4MIC_pip", "FTGTMIC_pip", "FTGT4MIC_pip",
+    "TGTMIC", "TGT4MIC", "FTGTMIC", "FTGT4MIC", "CONC", "CONCF",
+    "TGTMIC_taz", "FTGTMIC_taz", "AUC_pip", "AUC_taz"
+  ],
+  "parameters" : {
+    "ETACL": 1.0,
+    "ETAV1": 1.0,
+    "ETAV2": 1.0,
+    "CL_pip": 4.11,
+    "CLR_pip": 0.0613,
+    "V_pip": 29.7,
+    "V2_pip": 4.26,
+    "Q_pip": 3.27,
+    "CL_taz": 2.49,
+    "V_taz": 30.3,
+    "V2_taz": 4.56,
+    "Q_taz": 3.44
+  },
+  "omega_matrix": [
+    0.917764,
+    0, 0.1936,
+    0, 0, 1.0
+  ],
+  "fixed": [
+    "CL_pip", "CLR_pip", "V_pip", "V2_pip", "Q_pip",
+    "CL_taz", "V_taz", "V2_taz", "Q_taz"
+  ],
+  "iov": {
+    "use": true,
+    "cv": {
+      "CLR": 0.315
+    },
+    "n_bins": 2,
+    "bins": [0, 48, 9999]
+  },
+  "ruv": {
+    "prop": [ 0, 0, 0, 0],
+    "add": [ 0.28, 0.254, 0.28, 0.254]
+  },
+  "misc": {
+    "model_type": "2cmt_iv",
+    "linearity": "nonlinear",
+    "timevarying_parameter": false,
+    "init_parameter": false
+  },
+  "references": [
+    {
+      "ref": "Wallenburg, E., et al. Clinical Pharmacokinetics, 2022",
+      "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9249689/"
+    }
+  ],
+  "version": "0.1.6"
+}


### PR DESCRIPTION
This PR provides access to 22 additional beta lactam models, following the standard in this repo in terms of which metadata fields are included.
